### PR TITLE
removed explicit shared apiclients closing

### DIFF
--- a/argocd/provider.go
+++ b/argocd/provider.go
@@ -18,7 +18,7 @@ import (
 
 var apiClientConnOpts apiclient.ClientOptions
 
-func Provider(doneCh chan bool) terraform.ResourceProvider {
+func Provider() terraform.ResourceProvider {
 	return &schema.Provider{
 		Schema: map[string]*schema.Schema{
 			"server_addr": {
@@ -113,34 +113,25 @@ func Provider(doneCh chan bool) terraform.ResourceProvider {
 			if err != nil {
 				return nil, err
 			}
-			pcCloser, projectClient, err := apiClient.NewProjectClient()
+			_, projectClient, err := apiClient.NewProjectClient()
 			if err != nil {
 				return nil, err
 			}
 
-			acCloser, applicationClient, err := apiClient.NewApplicationClient()
+			_, applicationClient, err := apiClient.NewApplicationClient()
 			if err != nil {
 				return nil, err
 			}
 
-			rcCloser, repositoryClient, err := apiClient.NewRepoClient()
+			_, repositoryClient, err := apiClient.NewRepoClient()
 			if err != nil {
 				return nil, err
 			}
 
-			rcredsCloser, repoCredsClient, err := apiClient.NewRepoCredsClient()
+			_, repoCredsClient, err := apiClient.NewRepoCredsClient()
 			if err != nil {
 				return nil, err
 			}
-
-			// Clients connection pooling, close when the provider execution ends
-			go func(done chan bool) {
-				<-done
-				util.Close(pcCloser)
-				util.Close(acCloser)
-				util.Close(rcCloser)
-				util.Close(rcredsCloser)
-			}(doneCh)
 			return initServerInterface(
 				apiClient,
 				projectClient,

--- a/argocd/provider_test.go
+++ b/argocd/provider_test.go
@@ -9,24 +9,22 @@ import (
 
 var testAccProviders map[string]terraform.ResourceProvider
 var testAccProvider *schema.Provider
-var testDoneCh = make(chan bool, 1)
 
 func init() {
-	testAccProvider = Provider(testDoneCh).(*schema.Provider)
+	testAccProvider = Provider().(*schema.Provider)
 	testAccProviders = map[string]terraform.ResourceProvider{
 		"argocd": testAccProvider,
 	}
-	testDoneCh <- true
 }
 
 func TestProvider(t *testing.T) {
-	if err := Provider(testDoneCh).(*schema.Provider).InternalValidate(); err != nil {
+	if err := Provider().(*schema.Provider).InternalValidate(); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 }
 
 func TestProvider_impl(t *testing.T) {
-	var _ = Provider(testDoneCh)
+	var _ = Provider()
 }
 
 func testAccPreCheck(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -7,13 +7,9 @@ import (
 )
 
 func main() {
-	// ArgoCD services connection pool closing channel
-	var doneCh = make(chan bool, 1)
-
 	plugin.Serve(&plugin.ServeOpts{
 		ProviderFunc: func() terraform.ResourceProvider {
-			return argocd.Provider(doneCh)
+			return argocd.Provider()
 		},
 	})
-	doneCh <- true
 }


### PR DESCRIPTION
Closes #23

Workaround for apiclients closure race condition, needs more future work to properly wait for all provider activity to end before closing those.