### PR TITLE
Handle absent resources upon deletion, force argocd_repository connection cache refreshes upon reads

### DIFF
--- a/argocd/resource_argocd_application.go
+++ b/argocd/resource_argocd_application.go
@@ -150,7 +150,7 @@ func resourceArgoCDApplicationDelete(d *schema.ResourceData, meta interface{}) e
 	c := *server.ApplicationClient
 	appName := d.Id()
 	_, err := c.Delete(context.Background(), &applicationClient.ApplicationDeleteRequest{Name: &appName})
-	if err != nil {
+	if err != nil && !strings.Contains(err.Error(), "NotFound") {
 		return err
 	}
 	d.SetId("")

--- a/argocd/resource_argocd_project.go
+++ b/argocd/resource_argocd_project.go
@@ -174,7 +174,7 @@ func resourceArgoCDProjectDelete(d *schema.ResourceData, meta interface{}) error
 	_, err := c.Delete(context.Background(), &projectClient.ProjectQuery{Name: projectName})
 	tokenMutexProjectMap[projectName].Unlock()
 
-	if err != nil {
+	if err != nil && !strings.Contains(err.Error(), "NotFound") {
 		return err
 	}
 	d.SetId("")

--- a/argocd/resource_argocd_repository_credentials.go
+++ b/argocd/resource_argocd_repository_credentials.go
@@ -117,7 +117,14 @@ func resourceArgoCDRepositoryCredentialsDelete(d *schema.ResourceData, meta inte
 	tokenMutexConfiguration.Unlock()
 
 	if err != nil {
-		return err
+		switch strings.Contains(err.Error(), "NotFound") {
+		// Repository credentials have already been deleted in an out-of-band fashion
+		case true:
+			d.SetId("")
+			return nil
+		default:
+			return err
+		}
 	}
 	d.SetId("")
 	return nil


### PR DESCRIPTION
Closes #31 
Closes #32 