### PR TITLE
Portable, cross-platform tests settings

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,9 +34,9 @@ jobs:
           curl -sL "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash
           chmod +x ./kustomize
 
-      - name: Install Kind 0.8.1
+      - name: Install Kind 0.9.0
         run: |
-          curl -sLo ./kind https://kind.sigs.k8s.io/dl/v0.8.1/kind-$(uname)-amd64
+          curl -sLo ./kind https://kind.sigs.k8s.io/dl/v0.9.0/kind-$(uname)-amd64
           chmod +x ./kind
 
       - name: Set up ArgoCD ${{ matrix.argocd_version }}
@@ -45,7 +45,6 @@ jobs:
         run: |
           curl https://raw.githubusercontent.com/argoproj/argo-cd/${ARGOCD_VERSION}/manifests/install.yaml > manifests/install/install.yml
           sh scripts/testacc_prepare_env.sh
-          kubectl port-forward -n argocd service/argocd-server --address 127.0.0.1 8080:443&
           until $(nc -z 127.0.0.1 8080); do sleep 2;done
           netstat -tulpn
 

--- a/.run/Template Go Test.run.xml
+++ b/.run/Template Go Test.run.xml
@@ -1,0 +1,21 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="true" type="GoTestRunConfiguration" factoryName="Go Test">
+    <module name="terraform-provider-argocd" />
+    <working_directory value="$PROJECT_DIR$" />
+    <go_parameters value="-i" />
+    <envs>
+      <env name="ARGOCD_INSECURE" value="true" />
+      <env name="ARGOCD_SERVER" value="127.0.0.1:8080" />
+      <env name="ARGOCD_AUTH_USERNAME" value="admin" />
+      <env name="ARGOCD_AUTH_PASSWORD" value="acceptancetesting" />
+      <env name="ARGOCD_CONTEXT" value="kind-argocd" />
+      <env name="TF_ACC" value="1" />
+    </envs>
+    <framework value="gotest" />
+    <kind value="DIRECTORY" />
+    <package value="github.com/oboukili/terraform-provider-argocd" />
+    <directory value="$PROJECT_DIR$" />
+    <filePath value="$PROJECT_DIR$" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/README.md
+++ b/README.md
@@ -43,7 +43,26 @@ In these cases, not only the readability of your Terraform plan will worsen, but
 
 ## Installation
 
-* **From binary releases**:
+* **From Terraform Public Registry (TF >= 0.13.0)**
+
+  https://registry.terraform.io/providers/oboukili/argocd/latest
+  ```hcl
+    terraform {
+      required_providers {
+        argocd = {
+          source = "oboukili/argocd"
+          version = "0.4.7"
+        }
+      }
+    }
+
+    provider "argocd" {
+      # Configuration options
+    }
+  ```
+
+
+* **From binary releases (TF >= 0.12.0, < 0.13)**:
   Get the [latest release](https://github.com/oboukili/terraform-provider-argocd/releases/latest), or adapt and run the following:
   ```shell script
   curl -LO https://github.com/oboukili/terraform-provider-argocd/releases/download/v0.1.0/terraform-provider-argocd_v0.1.0_linux_amd64.gz
@@ -181,7 +200,7 @@ resource "argocd_application" "kustomize" {
     source {
       repo_url        = "https://github.com/kubernetes-sigs/kustomize"
       path            = "examples/helloWorld"
-      target_revision = "master"
+      target_revision = "release-kustomize-v3.7"
       kustomize {
         name_prefix = "foo-"
         name_suffix = "-bar"

--- a/argocd/resource_argocd_application_test.go
+++ b/argocd/resource_argocd_application_test.go
@@ -83,7 +83,7 @@ ingress:
 					resource.TestCheckResourceAttr(
 						"argocd_application.kustomize",
 						"spec.0.source.0.target_revision",
-						"master",
+						"release-kustomize-v3.7",
 					),
 					resource.TestCheckResourceAttr(
 						"argocd_application.kustomize",
@@ -256,7 +256,7 @@ resource "argocd_application" "kustomize" {
     source {
       repo_url        = "https://github.com/kubernetes-sigs/kustomize"
       path            = "examples/helloWorld"
-      target_revision = "master"
+      target_revision = "release-kustomize-v3.7"
       kustomize {
   	    name_prefix  = "foo-"
 	  	name_suffix = "-bar"

--- a/argocd/resource_argocd_repository_test.go
+++ b/argocd/resource_argocd_repository_test.go
@@ -91,8 +91,9 @@ resource "argocd_application" "public" {
   }
   spec {
     source {
-      repo_url = argocd_repository.simple.repo
-      path     = "examples/helloWorld"
+      repo_url        = argocd_repository.simple.repo
+      path            = "examples/helloWorld"
+      target_revision = "release-kustomize-v3.7"
     }
     destination {
       server    = "https://kubernetes.default.svc"

--- a/manifests/install/kustomization.yml
+++ b/manifests/install/kustomization.yml
@@ -6,6 +6,7 @@ resources:
   - namespace.yml
   - install.yml
   - git-private-repository.yml
+  - proxy-service.yml
 patchesStrategicMerge:
   - patches/deployment.yml
   - patches/secret.yml

--- a/manifests/install/proxy-service.yml
+++ b/manifests/install/proxy-service.yml
@@ -1,0 +1,21 @@
+---
+# Access to argocd service port without the need to proxy through kubectl proxy
+apiVersion: v1
+kind: Service
+metadata:
+  name: argocd-server-proxy
+spec:
+  type: NodePort
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      nodePort: 30124
+      targetPort: 8080
+    - name: https
+      port: 443
+      protocol: TCP
+      nodePort: 30123
+      targetPort: 8080
+  selector:
+    app.kubernetes.io/name: argocd-server

--- a/scripts/kind-config.yml
+++ b/scripts/kind-config.yml
@@ -1,0 +1,11 @@
+---
+apiVersion: kind.x-k8s.io/v1alpha4
+kind: Cluster
+nodes:
+  - role: control-plane
+    # Access ArgoCD API server on a MacOS / Windows workstation easily
+    extraPortMappings:
+      - containerPort: 30123
+        hostPort: 8080
+        listenAddress: "0.0.0.0"
+        protocol: TCP

--- a/scripts/testacc_prepare_env.sh
+++ b/scripts/testacc_prepare_env.sh
@@ -7,16 +7,25 @@ echo '--- Kustomize sanity checks'
 kustomize version || exit 1
 
 echo '--- Create Kind cluster\n\n'
-kind create cluster --name argocd
+kind create cluster --name argocd --config scripts/kind-config.yml --image kindest/node:${ARGOCD_KUBERNETES_VERSION:-v1.18.8}
 
 echo '--- Kind sanity checks\n\n'
 kubectl get nodes -o wide
 kubectl get pods --all-namespaces -o wide
 kubectl get services --all-namespaces -o wide
 
+echo '--- Load already available container images from local registry into Kind'
+kind load docker-image redis:5.0.3 --name argocd
+kind load docker-image quay.io/dexidp/dex:v2.22.0 --name argocd
+kind load docker-image argoproj/argocd:${ARGOCD_VERSION:-v1.6.1} --name argocd
+
 echo '--- Install ArgoCD ${ARGOCD_VERSION:-v1.6.1}\n\n'
 kustomize build manifests/install | kubectl apply -f - &&
 kubectl apply -f manifests/testdata/ &&
 
-echo '--- Wait for ArgoCD server to be ready...'
+echo '--- Wait for ArgoCD components to be ready...'
 kubectl wait --for=condition=available --timeout=600s deployment/argocd-server -n argocd
+kubectl wait --for=condition=available --timeout=30s deployment/argocd-repo-server -n argocd
+kubectl wait --for=condition=available --timeout=30s deployment/argocd-application-controller -n argocd
+kubectl wait --for=condition=available --timeout=30s deployment/argocd-dex-server -n argocd
+kubectl wait --for=condition=available --timeout=30s deployment/argocd-redis -n argocd


### PR DESCRIPTION
* persisted Goland gotest templates
* made Kind test settings cross-platform through extraPortMappings
* removed CI testing dependencies with kubectl proxy
* side-loads local container registry images into Kind during cluster initialization
* updated Github Actions accordingly
* fixed Kustomize tests, targeting kubernetes-sigs/kustomize release-kustomize-3.7 branch instead of master (breaking changes introduced within Kustomize examples)

closes #41 