### PR TITLE
argocd_project: handles orphaned_resources/ignore, signature_keys

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        argocd_version: ["v.1.8.3", "v1.7.11", "v1.6.2"]
+        argocd_version: ["v.1.8.3", "v1.7.11"]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v1

--- a/README.md
+++ b/README.md
@@ -138,8 +138,19 @@ resource "argocd_project" "myproject" {
       group = "networking.k8s.io"
       kind  = "Ingress"
     }
-    orphaned_resources = {
+    orphaned_resources {
       warn = true
+
+      ignore {
+        group = "apps/v1"
+        kind  = "Deployment"
+        name  = "ignored1"
+      }
+      ignore {
+        group = "apps/v1"
+        kind  = "Deployment"
+        name  = "ignored2"
+      }
     }
     role {
       name = "testrole"

--- a/README.md
+++ b/README.md
@@ -184,6 +184,10 @@ resource "argocd_project" "myproject" {
       schedule     = "22 1 5 * *"
       manual_sync  = false
     }
+    signature_keys = [
+      "4AEE18F83AFDEB23",
+      "07E34825A909B250"
+    ]
   }
 }
 

--- a/argocd/resource_argocd_project.go
+++ b/argocd/resource_argocd_project.go
@@ -148,6 +148,13 @@ func resourceArgoCDProjectUpdate(d *schema.ResourceData, meta interface{}) error
 			for _, r := range roles {
 				pr, i, err := p.GetRoleByName(r.Name)
 				if err != nil {
+					switch i {
+					default:
+					// i == -1 means the role does not exist
+					// and was recently added within Terraform tf files
+					case -1:
+						continue
+					}
 					return err
 				}
 				projectRequest.Project.Spec.Roles[i].JWTTokens = pr.JWTTokens

--- a/argocd/resource_argocd_project_test.go
+++ b/argocd/resource_argocd_project_test.go
@@ -151,8 +151,18 @@ resource "argocd_project" "simple" {
       group = "networking.k8s.io"
       kind  = "Ingress"
     }
-    orphaned_resources = {
+    orphaned_resources {
       warn = true
+      ignore {
+        group = "apps/v1"
+        kind  = "Deployment"
+        name  = "ignored1"
+      }
+      ignore {
+        group = "apps/v1"
+        kind  = "Deployment"
+        name  = "ignored2"
+      }
     }
     sync_window {
       kind = "allow"

--- a/argocd/resource_argocd_project_test.go
+++ b/argocd/resource_argocd_project_test.go
@@ -182,6 +182,10 @@ resource "argocd_project" "simple" {
       schedule = "22 1 5 * *"
       manual_sync = false
     }
+    signature_keys = [
+      "4AEE18F83AFDEB23",
+      "07E34825A909B250"
+    ]
   }
 }
 	`, name)

--- a/argocd/schema_project.go
+++ b/argocd/schema_project.go
@@ -136,6 +136,11 @@ func projectSpecSchema() *schema.Schema {
 					Required: true,
 					Elem:     &schema.Schema{Type: schema.TypeString},
 				},
+				"signature_keys": {
+					Type:     schema.TypeList,
+					Optional: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
 				"sync_window": {
 					Type:     schema.TypeList,
 					Optional: true,

--- a/argocd/schema_project.go
+++ b/argocd/schema_project.go
@@ -70,9 +70,39 @@ func projectSpecSchema() *schema.Schema {
 					},
 				},
 				"orphaned_resources": {
-					Type:     schema.TypeMap,
+					Type:     schema.TypeSet,
 					Optional: true,
-					Elem:     &schema.Schema{Type: schema.TypeBool},
+					MinItems: 1,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"warn": {
+								Type:     schema.TypeBool,
+								Optional: true,
+							},
+							"ignore": {
+								Type:     schema.TypeSet,
+								Optional: true,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"group": {
+											Type:         schema.TypeString,
+											ValidateFunc: validateGroupName,
+											Optional:     true,
+										},
+										"kind": {
+											Type:     schema.TypeString,
+											Optional: true,
+										},
+										"name": {
+											Type:     schema.TypeString,
+											Optional: true,
+										},
+									},
+								},
+							},
+						},
+					},
 				},
 				"role": {
 					Type:     schema.TypeList,

--- a/argocd/schema_project.go
+++ b/argocd/schema_project.go
@@ -72,7 +72,6 @@ func projectSpecSchema() *schema.Schema {
 				"orphaned_resources": {
 					Type:     schema.TypeSet,
 					Optional: true,
-					MinItems: 1,
 					MaxItems: 1,
 					Elem: &schema.Resource{
 						Schema: map[string]*schema.Schema{

--- a/argocd/structure_project.go
+++ b/argocd/structure_project.go
@@ -64,7 +64,8 @@ func expandProjectSpec(d *schema.ResourceData) (
 	}
 	if v, ok := s["orphaned_resources"]; ok {
 		spec.OrphanedResources = &application.OrphanedResourcesMonitorSettings{}
-		if _warn, _ok := v.(map[string]interface{})["warn"]; _ok {
+		orphanedResources := v.(*schema.Set).List()[0]
+		if _warn, _ok := orphanedResources.(map[string]interface{})["warn"]; _ok {
 			warn := _warn.(bool)
 			spec.OrphanedResources.Warn = &warn
 		}

--- a/argocd/structure_project.go
+++ b/argocd/structure_project.go
@@ -157,17 +157,15 @@ func flattenProjectSignatureKeys(keys []application.SignatureKey) (
 	return
 }
 
-func flattenProjectOrphanedResources(ors *application.OrphanedResourcesMonitorSettings) (
-	result []map[string]interface{}) {
+func flattenProjectOrphanedResources(ors *application.OrphanedResourcesMonitorSettings) []map[string]interface{} {
+	result := make(map[string]interface{}, 0)
 	if ors != nil {
-		result = []map[string]interface{}{
-			{
-				"warn":   *ors.Warn,
-				"ignore": flattenProjectOrphanedResourcesIgnore(ors.Ignore),
-			},
+		if ors.Warn != nil {
+			result["warn"] = *ors.Warn
 		}
+		result["ignore"] = flattenProjectOrphanedResourcesIgnore(ors.Ignore)
 	}
-	return
+	return []map[string]interface{}{result}
 }
 
 func flattenProjectOrphanedResourcesIgnore(ignore []application.OrphanedResourceKey) (

--- a/argocd/structure_project.go
+++ b/argocd/structure_project.go
@@ -64,14 +64,16 @@ func expandProjectSpec(d *schema.ResourceData) (
 	}
 	if v, ok := s["orphaned_resources"]; ok {
 		spec.OrphanedResources = &application.OrphanedResourcesMonitorSettings{}
-		orphanedResources := v.(*schema.Set).List()[0]
-		if _warn, _ok := orphanedResources.(map[string]interface{})["warn"]; _ok {
-			warn := _warn.(bool)
-			spec.OrphanedResources.Warn = &warn
-		}
-		if _ignore, _ok := v.(map[string]interface{})["ignore"]; _ok {
-			ignore := expandOrphanedResourcesIgnore(_ignore.(*schema.Set))
-			spec.OrphanedResources.Ignore = ignore
+		orphanedResources := v.(*schema.Set).List()
+		if len(orphanedResources) > 0 {
+			if _warn, _ok := orphanedResources[0].(map[string]interface{})["warn"]; _ok {
+				warn := _warn.(bool)
+				spec.OrphanedResources.Warn = &warn
+			}
+			if _ignore, _ok := orphanedResources[0].(map[string]interface{})["ignore"]; _ok {
+				ignore := expandOrphanedResourcesIgnore(_ignore.(*schema.Set))
+				spec.OrphanedResources.Ignore = ignore
+			}
 		}
 	}
 	if v, ok := s["cluster_resource_whitelist"]; ok {

--- a/argocd/structure_project.go
+++ b/argocd/structure_project.go
@@ -55,6 +55,13 @@ func expandProjectSpec(d *schema.ResourceData) (
 			spec.SourceRepos = append(spec.SourceRepos, sr.(string))
 		}
 	}
+	if v, ok := s["signature_keys"]; ok {
+		for _, sk := range v.([]interface{}) {
+			spec.SignatureKeys = append(spec.SignatureKeys, application.SignatureKey{
+				KeyID: sk.(string),
+			})
+		}
+	}
 	if v, ok := s["orphaned_resources"]; ok {
 		spec.OrphanedResources = &application.OrphanedResourcesMonitorSettings{}
 		if _warn, _ok := v.(map[string]interface{})["warn"]; _ok {
@@ -134,8 +141,17 @@ func flattenProjectSpec(s application.AppProjectSpec) []map[string]interface{} {
 		"sync_window":                  flattenSyncWindows(s.SyncWindows),
 		"description":                  s.Description,
 		"source_repos":                 s.SourceRepos,
+		"signature_keys":               flattenProjectSignatureKeys(s.SignatureKeys),
 	}
 	return []map[string]interface{}{spec}
+}
+
+func flattenProjectSignatureKeys(keys []application.SignatureKey) (
+	result []string) {
+	for _, key := range keys {
+		result = append(result, key.KeyID)
+	}
+	return
 }
 
 func flattenProjectOrphanedResources(ors *application.OrphanedResourcesMonitorSettings) (

--- a/argocd/structure_project.go
+++ b/argocd/structure_project.go
@@ -157,15 +157,19 @@ func flattenProjectSignatureKeys(keys []application.SignatureKey) (
 	return
 }
 
-func flattenProjectOrphanedResources(ors *application.OrphanedResourcesMonitorSettings) []map[string]interface{} {
-	result := make(map[string]interface{}, 0)
+func flattenProjectOrphanedResources(ors *application.OrphanedResourcesMonitorSettings) (
+	result []map[string]interface{}) {
+	r := make(map[string]interface{}, 0)
 	if ors != nil {
 		if ors.Warn != nil {
-			result["warn"] = *ors.Warn
+			r["warn"] = *ors.Warn
 		}
-		result["ignore"] = flattenProjectOrphanedResourcesIgnore(ors.Ignore)
+		if ors.Ignore != nil {
+			r["ignore"] = flattenProjectOrphanedResourcesIgnore(ors.Ignore)
+			result = append(result, r)
+		}
 	}
-	return []map[string]interface{}{result}
+	return
 }
 
 func flattenProjectOrphanedResourcesIgnore(ignore []application.OrphanedResourceKey) (

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -45,8 +45,20 @@ resource "argocd_project" "myproject" {
       group = "networking.k8s.io"
       kind  = "Ingress"
     }
-    orphaned_resources = {
+    orphaned_resources {
       warn = true
+
+      ignore {
+        group = "apps/v1"
+        kind  = "Deployment"
+        name  = "ignored1"
+      }
+
+      ignore {
+        group = "apps/v1"
+        kind  = "Deployment"
+        name  = "ignored2"
+      }
     }
     role {
       name = "testrole"
@@ -111,8 +123,14 @@ Each `cluster_resource_whitelist` block can have the following attributes:
 * `group` - (Optional) The Kubernetes resource Group to match for.
 * `kind` - (Optional) The Kubernetes resource Kind to match for.
 
-The `orphaned_resources` map can have the following attributes:
-* `warn` - Boolean, defaults to `false`.
+The `orphaned_resources` block can have the following attributes:
+* `warn` - (Optional) Boolean, defaults to `false`.
+* `ignore` - (Optional), set of map of strings, specifies which Group/Kind/Name resource(s) to ignore. Can be repeated multiple times. Structure is documented below.
+
+Each `orphaned_resources/ignore` block can have the following attributes:
+* `group` - (Optional) The Kubernetes resource Group to match for.
+* `kind` - (Optional) The Kubernetes resource Kind to match for.
+* `name` - (Optional) The Kubernetes resource name to match for.
 
 Each `namespace_resource_blacklist` block can have the following attributes:
 * `group` - (Optional) The Kubernetes resource Group to match for.

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -92,6 +92,10 @@ resource "argocd_project" "myproject" {
       schedule     = "22 1 5 * *"
       manual_sync  = false
     }
+    signature_keys = [
+      "4AEE18F83AFDEB23",
+      "07E34825A909B250"
+    ]
   }
 }
 
@@ -118,6 +122,7 @@ The `spec` block can have the following attributes:
 * `namespace_resource_blacklist` - (Optional) Namespaced-scoped resources allowed to be managed by the project applications, can be repeated multiple times. 
 * `role` - (Optional) can be repeated multiple times. 
 * `sync_window` - (Optional) can be repeated multiple times. 
+* `signature_keys` - (Optional) list of PGP key IDs strings that commits to be synced to must be signed with.
 
 Each `cluster_resource_whitelist` block can have the following attributes:
 * `group` - (Optional) The Kubernetes resource Group to match for.
@@ -150,6 +155,7 @@ Each `sync_window` block can have the following attributes:
 * `manual_sync` - (Optional) Boolean, enables manual syncs when they would otherwise be blocked.
 * `namespaces` - (Optional) List of namespaces that the window will apply to.
 * `schedule` - (Optional) Time the window will begin, specified in cron format.
+
 
 ## Import
 


### PR DESCRIPTION
**BREAKING CHANGES**:
 argocd_project.spec.0.orphaned_resources attribute has been changed from a map to a set of map.

From
```hcl
    orphaned_resources = {
      warn = true
    }
```

To
```hcl
    orphaned_resources {
      warn = true
    }
```

Closes #49 

**BUGFIX:**
Fix project updates when adding new project roles. (Closes #51 )