### PR TITLE
ignore notified.notifications.argoproj.io annotations

### DIFF
--- a/argocd/structure_metadata.go
+++ b/argocd/structure_metadata.go
@@ -59,5 +59,8 @@ func metadataIsInternalKey(annotationKey string) bool {
 	if err == nil && strings.HasSuffix(u.Hostname(), "kubernetes.io") {
 		return true
 	}
+	if err == nil && annotationKey == "notified.notifications.argoproj.io" {
+		return true
+	}
 	return false
 }

--- a/argocd/structure_metadata_test.go
+++ b/argocd/structure_metadata_test.go
@@ -16,6 +16,7 @@ func TestMetadataIsInternalKey(t *testing.T) {
 		{"any.hostname.com/with/path", false},
 		{"any.kubernetes.io", true},
 		{"kubernetes.io", true},
+		{"notified.notifications.argoproj.io", true},
 	}
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {


### PR DESCRIPTION
Hi,

I use [Argo CD Notifications](https://argocd-notifications.readthedocs.io/en/stable/) which store dynamically some datas into an annotation named : **notified.notifications.argoproj.io**.

Example : 
```
apiVersion: argoproj.io/v1alpha1
kind: Application
metadata:
  annotations:
    notifications.argoproj.io/subscribe.on-created.grafana: platform-created
    notified.notifications.argoproj.io: '{"my-app-dev1:on-created:[0].Y_9K23NSHEAsZ2kqeSw2_KxnMps:grafana:argocd":1618503285,"my-app-dev1:on-created:[0].Y_9K23NSHEAsZ2kqeSw2_KxnMps:grafana:platform-created":1618503285,"my-app-dev1:on-created:[0].Y_9K23NSHEAsZ2kqeSw2_KxnMps:teams:my-team":1618503284}'
  creationTimestamp: "2021-04-15T16:14:44Z"`
```

I have change each time i run terraform ...
Could you implement this little feature ?

In accordance to [running-tests](https://github.com/oboukili/terraform-provider-argocd#running-tests), tests pass succesfully.
I build binary a test it, it's works like a charm : I have no more change.

```
ARGOCD_INSECURE=true \                                                   
ARGOCD_SERVER=127.0.0.1:8080 \
ARGOCD_AUTH_USERNAME=admin \
ARGOCD_AUTH_PASSWORD=acceptancetesting \
ARGOCD_CONTEXT=kind-argocd \
TF_ACC=1 go test github.com/oboukili/terraform-provider-argocd/argocd -v -timeout 5m -run TestMetadataIsInternalKey
=== RUN   TestMetadataIsInternalKey
=== RUN   TestMetadataIsInternalKey/0
=== RUN   TestMetadataIsInternalKey/1
=== RUN   TestMetadataIsInternalKey/2
=== RUN   TestMetadataIsInternalKey/3
=== RUN   TestMetadataIsInternalKey/4
=== RUN   TestMetadataIsInternalKey/5
=== RUN   TestMetadataIsInternalKey/6
--- PASS: TestMetadataIsInternalKey (0.00s)
    --- PASS: TestMetadataIsInternalKey/0 (0.00s)
    --- PASS: TestMetadataIsInternalKey/1 (0.00s)
    --- PASS: TestMetadataIsInternalKey/2 (0.00s)
    --- PASS: TestMetadataIsInternalKey/3 (0.00s)
    --- PASS: TestMetadataIsInternalKey/4 (0.00s)
    --- PASS: TestMetadataIsInternalKey/5 (0.00s)
    --- PASS: TestMetadataIsInternalKey/6 (0.00s)
PASS
ok  	github.com/oboukili/terraform-provider-argocd/argocd	(cached)
```

Regards,