### PR TITLE
Add support for GRPCWebRootPath ArgoCD ApiClient ClientOption

### DIFF
--- a/argocd/provider.go
+++ b/argocd/provider.go
@@ -89,6 +89,10 @@ func Provider() terraform.ResourceProvider {
 				Type:     schema.TypeBool,
 				Optional: true,
 			},
+			"grpc_web_root_path": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			"port_forward": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -218,6 +222,9 @@ func initApiClient(d *schema.ResourceData) (
 	}
 	if v, ok := d.GetOk("grpc_web"); ok {
 		opts.GRPCWeb = v.(bool)
+	}
+	if v, ok := d.GetOk("grpc_web_root_path"); ok {
+		opts.GRPCWebRootPath = v.(string)
 	}
 	if v, ok := d.GetOk("port_forward"); ok {
 		opts.PortForward = v.(bool)

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,7 +21,8 @@ provider "argocd" {
 * `plain_text` - (Optional) Boolean, whether to initiate an unencrypted connection to ArgoCD server. 
 * `context` - (Optional) Kubernetes context to load from an existing `.kube/config` file. Can be set through `ARGOCD_CONTEXT` environment variable.
 * `user_agent` - (Optional)
-* `grpc_web` - (Optional) Whether to use gRPC web proxy client.
+* `grpc_web` - (Optional) Whether to use gRPC web proxy client. Useful if Argo CD server is behind proxy which does not support HTTP2.
+* `grpc_web_root_path` - (Optional) Use the gRPC web proxy client and set the web root, e.g. `argo-cd`. Useful if the Argo CD server is behind a proxy at a non-root path.
 * `port_forward` - (Optional)
 * `port_forward_with_namespace` - (Optional)
 * `headers` - (Optional) Additional headers to add to each request to the ArgoCD server.


### PR DESCRIPTION
Cfr. argocd docs on running argocd at a different UI root path: [ArgoCD Server and UI Root Path (v1.5.3)](https://argo-cd.readthedocs.io/en/stable/operator-manual/ingress/#argocd-server-and-ui-root-path-v153) 