### PR TITLE
Add support for NamespaceResourceWhitelist and ClusterResourceBlacklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,10 @@ resource "argocd_project" "myproject" {
       server    = "https://kubernetes.default.svc"
       namespace = "foo"
     }
+    cluster_resource_blacklist {
+      group = "*"
+      kind  = "*"
+    }
     cluster_resource_whitelist {
       group = "rbac.authorization.k8s.io"
       kind  = "ClusterRoleBinding"
@@ -151,6 +155,10 @@ resource "argocd_project" "myproject" {
     namespace_resource_blacklist {
       group = "networking.k8s.io"
       kind  = "Ingress"
+    }
+    namespace_resource_whitelist {
+      group = "*"
+      kind  = "*"
     }
     orphaned_resources {
       warn = true

--- a/argocd/resource_argocd_project_test.go
+++ b/argocd/resource_argocd_project_test.go
@@ -147,9 +147,17 @@ resource "argocd_project" "simple" {
       group = "rbac.authorization.k8s.io"
       kind  = "ClusterRole"
     }
+    cluster_resource_blacklist {
+      group = "*"
+      kind  = "*"
+    }
     namespace_resource_blacklist {
       group = "networking.k8s.io"
       kind  = "Ingress"
+    }
+    namespace_resource_whitelist {
+      group = "*"
+      kind  = "*"
     }
     orphaned_resources {
       warn = true

--- a/argocd/schema_project.go
+++ b/argocd/schema_project.go
@@ -15,6 +15,23 @@ func projectSpecSchemaV0() *schema.Schema {
 		Required:    true,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
+				"cluster_resource_blacklist": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"group": {
+								Type:         schema.TypeString,
+								ValidateFunc: validateGroupName,
+								Optional:     true,
+							},
+							"kind": {
+								Type:     schema.TypeString,
+								Optional: true,
+							},
+						},
+					},
+				},
 				"cluster_resource_whitelist": {
 					Type:     schema.TypeSet,
 					Optional: true,
@@ -58,6 +75,22 @@ func projectSpecSchemaV0() *schema.Schema {
 					},
 				},
 				"namespace_resource_blacklist": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"group": {
+								Type:     schema.TypeString,
+								Optional: true,
+							},
+							"kind": {
+								Type:     schema.TypeString,
+								Optional: true,
+							},
+						},
+					},
+				},
+				"namespace_resource_whitelist": {
 					Type:     schema.TypeSet,
 					Optional: true,
 					Elem: &schema.Resource{
@@ -166,6 +199,23 @@ func projectSpecSchemaV1() *schema.Schema {
 		Required:    true,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
+				"cluster_resource_blacklist": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"group": {
+								Type:         schema.TypeString,
+								ValidateFunc: validateGroupName,
+								Optional:     true,
+							},
+							"kind": {
+								Type:     schema.TypeString,
+								Optional: true,
+							},
+						},
+					},
+				},
 				"cluster_resource_whitelist": {
 					Type:     schema.TypeSet,
 					Optional: true,
@@ -209,6 +259,22 @@ func projectSpecSchemaV1() *schema.Schema {
 					},
 				},
 				"namespace_resource_blacklist": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"group": {
+								Type:     schema.TypeString,
+								Optional: true,
+							},
+							"kind": {
+								Type:     schema.TypeString,
+								Optional: true,
+							},
+						},
+					},
+				},
+				"namespace_resource_whitelist": {
 					Type:     schema.TypeSet,
 					Optional: true,
 					Elem: &schema.Resource{
@@ -351,6 +417,23 @@ func projectSpecSchemaV2() *schema.Schema {
 		Required:    true,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
+				"cluster_resource_blacklist": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"group": {
+								Type:         schema.TypeString,
+								ValidateFunc: validateGroupName,
+								Optional:     true,
+							},
+							"kind": {
+								Type:     schema.TypeString,
+								Optional: true,
+							},
+						},
+					},
+				},
 				"cluster_resource_whitelist": {
 					Type:     schema.TypeSet,
 					Optional: true,
@@ -394,6 +477,22 @@ func projectSpecSchemaV2() *schema.Schema {
 					},
 				},
 				"namespace_resource_blacklist": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"group": {
+								Type:     schema.TypeString,
+								Optional: true,
+							},
+							"kind": {
+								Type:     schema.TypeString,
+								Optional: true,
+							},
+						},
+					},
+				},
+				"namespace_resource_whitelist": {
 					Type:     schema.TypeSet,
 					Optional: true,
 					Elem: &schema.Resource{

--- a/argocd/schema_project_test.go
+++ b/argocd/schema_project_test.go
@@ -68,6 +68,7 @@ func TestResourceArgoCDProjectStateUpgradeV0(t *testing.T) {
 			sourceState: map[string]interface{}{
 				"spec": []interface{}{
 					map[string]interface{}{
+						"cluster_resource_blacklist": []map[string]string{},
 						"cluster_resource_whitelist": []map[string]string{},
 						"description":                "test",
 						"destination": map[string]string{
@@ -75,6 +76,7 @@ func TestResourceArgoCDProjectStateUpgradeV0(t *testing.T) {
 							"server":    "https://testing.io",
 						},
 						"namespace_resource_blacklist": []map[string]string{},
+						"namespace_resource_whitelist": []map[string]string{},
 						"orphaned_resources":           map[string]bool{"warn": true},
 						"role":                         []map[string]interface{}{},
 						"source_repos":                 []string{"git@github.com:testing/test.git"},
@@ -85,6 +87,7 @@ func TestResourceArgoCDProjectStateUpgradeV0(t *testing.T) {
 			expectedState: map[string]interface{}{
 				"spec": []interface{}{
 					map[string]interface{}{
+						"cluster_resource_blacklist": []map[string]string{},
 						"cluster_resource_whitelist": []map[string]string{},
 						"description":                "test",
 						"destination": map[string]string{
@@ -92,6 +95,7 @@ func TestResourceArgoCDProjectStateUpgradeV0(t *testing.T) {
 							"server":    "https://testing.io",
 						},
 						"namespace_resource_blacklist": []map[string]string{},
+						"namespace_resource_whitelist": []map[string]string{},
 						"orphaned_resources":           []interface{}{map[string]bool{"warn": true}},
 						"role":                         []map[string]interface{}{},
 						"source_repos":                 []string{"git@github.com:testing/test.git"},

--- a/argocd/structure_project.go
+++ b/argocd/structure_project.go
@@ -76,11 +76,17 @@ func expandProjectSpec(d *schema.ResourceData) (
 			}
 		}
 	}
+	if v, ok := s["cluster_resource_blacklist"]; ok {
+		spec.ClusterResourceBlacklist = expandK8SGroupKind(v.(*schema.Set))
+	}
 	if v, ok := s["cluster_resource_whitelist"]; ok {
 		spec.ClusterResourceWhitelist = expandK8SGroupKind(v.(*schema.Set))
 	}
 	if v, ok := s["namespace_resource_blacklist"]; ok {
 		spec.NamespaceResourceBlacklist = expandK8SGroupKind(v.(*schema.Set))
+	}
+	if v, ok := s["namespace_resource_whitelist"]; ok {
+		spec.NamespaceResourceWhitelist = expandK8SGroupKind(v.(*schema.Set))
 	}
 	if v, ok := s["destination"]; ok {
 		spec.Destinations = expandApplicationDestinations(v.(*schema.Set))
@@ -136,8 +142,10 @@ func flattenProject(p *application.AppProject, d *schema.ResourceData) error {
 
 func flattenProjectSpec(s application.AppProjectSpec) []map[string]interface{} {
 	spec := map[string]interface{}{
+		"cluster_resource_blacklist":   flattenK8SGroupKinds(s.ClusterResourceBlacklist),
 		"cluster_resource_whitelist":   flattenK8SGroupKinds(s.ClusterResourceWhitelist),
 		"namespace_resource_blacklist": flattenK8SGroupKinds(s.NamespaceResourceBlacklist),
+		"namespace_resource_whitelist": flattenK8SGroupKinds(s.NamespaceResourceWhitelist),
 		"destination":                  flattenApplicationDestinations(s.Destinations),
 		"orphaned_resources":           flattenProjectOrphanedResources(s.OrphanedResources),
 		"role":                         flattenProjectRoles(s.Roles),

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -33,6 +33,10 @@ resource "argocd_project" "myproject" {
       name      = "anothercluster"
       namespace = "bar"
     }
+    cluster_resource_blacklist {
+      group = "*"
+      kind  = "*"
+    }
     cluster_resource_whitelist {
       group = "rbac.authorization.k8s.io"
       kind  = "ClusterRoleBinding"
@@ -44,6 +48,10 @@ resource "argocd_project" "myproject" {
     namespace_resource_blacklist {
       group = "networking.k8s.io"
       kind  = "Ingress"
+    }
+    namespace_resource_whitelist {
+      group = "*"
+      kind  = "*"
     }
     orphaned_resources {
       warn = true

--- a/manifests/local-dev/main.tf
+++ b/manifests/local-dev/main.tf
@@ -51,6 +51,10 @@ resource "argocd_project" "foo" {
       group = "networking.k8s.io"
       kind  = "Ingress"
     }
+    namespace_resource_whitelist {
+      group = "*"
+      kind  = "*"
+    }
     orphaned_resources {
       warn = true
     }


### PR DESCRIPTION
Currently this provider only supports NamespaceResourceBlacklist and ClusterResourceWhitelist for projects.

This PR adds support for NamespaceResourceWhitelist and ClusterResourceBlacklist to make these options complete and in line with what ArgoCD supports.