### PR TITLE
Fix application source plugin env vars

### DIFF
--- a/argocd/structure_application.go
+++ b/argocd/structure_application.go
@@ -97,8 +97,8 @@ func expandApplicationSourcePlugin(in []interface{}) *application.ApplicationSou
 		for _, v := range env.(*schema.Set).List() {
 			result.Env = append(result.Env,
 				&application.EnvEntry{
-					Name:  v.(map[string]string)["name"],
-					Value: v.(map[string]string)["value"],
+					Name:  v.(map[string]interface{})["name"].(string),
+					Value: v.(map[string]interface{})["value"].(string),
 				},
 			)
 		}


### PR DESCRIPTION
I created an Argo Application resource to use a Grafana Tanka plugin within a module like so:

```
resource "argocd_application" "application" {
  metadata {
    name      = var.application_name
    namespace =  var.application_namespace
  }

  wait = false

  spec {
    project = var.project_name

    source {
      repo_url        = var.repository_url
      path            = "."
      target_revision = var.application_target_revision
      plugin {
        name = "tanka"
        env {
          name = "TK_ENV"
          value = "clusters/${var.application_name}"
        }
      } 
    }

    destination {
      server    = var.destination_cluster_url
      namespace = var.destination_cluster_namespace 
    }

    sync_policy {
      automated = {
        prune       = var.sync_option_prune
        self_heal   = var.sync_option_self_heal
        allow_empty = var.sync_option_allow_empty
      }

      retry {
        limit   = "5"
        backoff = {
          duration     = "30s"
          max_duration = "2m"
          factor       = "2"
        }
      }
    }
  }
}
```

When I apply it I get a panic:

```
module.argocd_application["my-app"].argocd_application.application: Creating...

Stack trace from the terraform-provider-argocd_v1.2.2 plugin:

panic: interface conversion: interface {} is map[string]interface {}, not map[string]string

goroutine 203 [running]:
github.com/oboukili/terraform-provider-argocd/argocd.expandApplicationSourcePlugin(0xc001398be0, 0x1, 0x1, 0x6)
        github.com/oboukili/terraform-provider-argocd/argocd/structure_application.go:100 +0x3b3
github.com/oboukili/terraform-provider-argocd/argocd.expandApplicationSource(0x2208920, 0xc000967b90, 0xc0010f08d0, 0x2c, 0x3892350, 0x1, 0xc00064ba90, 0x4, 0x0, 0x0, ...)
        github.com/oboukili/terraform-provider-argocd/argocd/structure_application.go:82 +0x465
github.com/oboukili/terraform-provider-argocd/argocd.expandApplicationSpec(0xc00078cfc0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
        github.com/oboukili/terraform-provider-argocd/argocd/structure_application.go:49 +0x491
github.com/oboukili/terraform-provider-argocd/argocd.expandApplication(0xc00078cfc0, 0xc00064b984, 0xa, 0x0, 0x0, 0xc00064b999, 0x7, 0x0, 0x0, 0x0, ...)
        github.com/oboukili/terraform-provider-argocd/argocd/structure_application.go:19 +0x106
github.com/oboukili/terraform-provider-argocd/argocd.resourceArgoCDApplicationCreate(0xc00078cfc0, 0x24304a0, 0xc001148340, 0x2, 0x3ac8e80)
        github.com/oboukili/terraform-provider-argocd/argocd/resource_argocd_application.go:44 +0xc5
github.com/hashicorp/terraform-plugin-sdk/helper/schema.(*Resource).Apply(0xc000a5b320, 0xc000678af0, 0xc000452b40, 0x24304a0, 0xc001148340, 0x2205501, 0xc00139c2d8, 0xc0010850e0)
        github.com/hashicorp/terraform-plugin-sdk@v1.16.0/helper/schema/resource.go:310 +0x375
github.com/hashicorp/terraform-plugin-sdk/helper/schema.(*Provider).Apply(0xc000204700, 0xc00130fa38, 0xc000678af0, 0xc000452b40, 0xc00126d048, 0xc001157490, 0x2208920)
        github.com/hashicorp/terraform-plugin-sdk@v1.16.0/helper/schema/provider.go:294 +0x99
github.com/hashicorp/terraform-plugin-sdk/internal/helper/plugin.(*GRPCProviderServer).ApplyResourceChange(0xc00081a2f0, 0x28ca9e0, 0xc001207980, 0xc000034fc0, 0xc00081a2f0, 0xc001207980, 0xc000cbfba0)
        github.com/hashicorp/terraform-plugin-sdk@v1.16.0/internal/helper/plugin/grpc_provider.go:885 +0x8ab
github.com/hashicorp/terraform-plugin-sdk/internal/tfplugin5._Provider_ApplyResourceChange_Handler(0x2487ac0, 0xc00081a2f0, 0x28ca9e0, 0xc001207980, 0xc0010da5a0, 0x0, 0x28ca9e0, 0xc001207980, 0xc000052c00, 0x571)
        github.com/hashicorp/terraform-plugin-sdk@v1.16.0/internal/tfplugin5/tfplugin5.pb.go:3305 +0x214
google.golang.org/grpc.(*Server).processUnaryRPC(0xc0007d0380, 0x28e4ce0, 0xc000652d80, 0xc00030f600, 0xc0007f2840, 0x3a6a7a0, 0x0, 0x0, 0x0)
        google.golang.org/grpc@v1.30.0/server.go:1171 +0x522
google.golang.org/grpc.(*Server).handleStream(0xc0007d0380, 0x28e4ce0, 0xc000652d80, 0xc00030f600, 0x0)
        google.golang.org/grpc@v1.30.0/server.go:1494 +0xcc5
google.golang.org/grpc.(*Server).serveStreams.func1.2(0xc000338810, 0xc0007d0380, 0x28e4ce0, 0xc000652d80, 0xc00030f600)
        google.golang.org/grpc@v1.30.0/server.go:834 +0xa5
created by google.golang.org/grpc.(*Server).serveStreams.func1
        google.golang.org/grpc@v1.30.0/server.go:832 +0x1fd

Error: The terraform-provider-argocd_v1.2.2 plugin crashed!

This is always indicative of a bug within the plugin. It would be immensely
helpful if you could report the crash with the plugin's maintainers so that it
can be fixed. The output above should help diagnose the issue.

│ Error: Plugin did not respond
│ 
│   with module.argocd_application["my-app"].argocd_application.application,
│   on .terraform/modules/argocd_application/argocd-tanka-application-resource/application.tf line 1, in resource "argocd_application" "application":
│    1: resource "argocd_application" "application" {
│ 
│ The plugin encountered an error, and failed to respond to the
│ plugin.(*GRPCProvider).ApplyResourceChange call. The plugin logs may
│ contain more details.
```

With the commit in the PR the panic is no longer present. 
The acceptance tests pass, but I couldn't find a test that excercizes it.