### PR TITLE
fix: resource/argocd_cluster cannot update server url

### DIFF
--- a/argocd/schema_cluster.go
+++ b/argocd/schema_cluster.go
@@ -15,6 +15,7 @@ func clusterSchema() map[string]*schema.Schema {
 			Type:        schema.TypeString,
 			Description: "Server is the API server URL of the Kubernetes cluster",
 			Optional:    true,
+			ForceNew:    true,
 		},
 		"shard": {
 			Type:        schema.TypeString,


### PR DESCRIPTION
Resolves #137

Instead of trying to update cluster's server URL, we should recreate an object.