### PR TITLE
tests: add argocd 2.2.5 to test suite

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        argocd_version: ["v2.1.3", "v2.0.5", "v1.8.7"]
+        argocd_version: ["v2.2.5", "v2.1.10"]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v1

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## Compatibility promise
 
-This provider is compatible with _at least_ the last 2 major releases of ArgoCD (e.g, ranging from 1.(n).m, to 1.(n-1).0, where `n` is the latest available major version).
+This provider is compatible with _at least_ the last 2 minor releases of ArgoCD (e.g, ranging from 1.(n).m, to 1.(n-1).0, where `n` is the latest available minor version).
 
 Older releases are not supported and some resources may not work as expected.
 


### PR DESCRIPTION
To ensure that the provider works with the current version. Version 2.2.5 is added without any older versions being removed increasing the workflows executed. As per #141 I found it unclear which versions the provider should maintain compatibility with.