### PR TITLE
Improve cluster metadata support

### DIFF
--- a/argocd/features.go
+++ b/argocd/features.go
@@ -24,6 +24,7 @@ const (
 	featureRepositoryGet
 	featureTokenIDs
 	featureProjectScopedClusters
+	featureClusterMetadata
 )
 
 var (
@@ -33,6 +34,7 @@ var (
 		featureRepositoryGet:               semver.MustParse("1.6.0"),
 		featureTokenIDs:                    semver.MustParse("1.5.3"),
 		featureProjectScopedClusters:       semver.MustParse("2.2.0"),
+		featureClusterMetadata:             semver.MustParse("2.2.0"),
 	}
 )
 

--- a/argocd/resource_argocd_cluster.go
+++ b/argocd/resource_argocd_cluster.go
@@ -70,6 +70,28 @@ func resourceArgoCDClusterCreate(ctx context.Context, d *schema.ResourceData, me
 		}
 	}
 
+	featureClusterMetadataSupported, err := server.isFeatureSupported(featureClusterMetadata)
+	if err != nil {
+		return []diag.Diagnostic{
+			{
+				Severity: diag.Error,
+				Summary:  "feature not supported",
+				Detail:   err.Error(),
+			},
+		}
+	}
+
+	if !featureClusterMetadataSupported && (len(cluster.Annotations) != 0 || len(cluster.Labels) != 0) {
+		return []diag.Diagnostic{
+			{
+				Severity: diag.Error,
+				Summary: fmt.Sprintf(
+					"cluster metadata is only supported from ArgoCD %s onwards",
+					featureVersionConstraintsMap[featureClusterMetadata].String()),
+			},
+		}
+	}
+
 	c, err := client.Create(ctx, &clusterClient.ClusterCreateRequest{
 		Cluster: cluster, Upsert: true})
 	if err != nil {
@@ -170,6 +192,28 @@ func resourceArgoCDClusterUpdate(ctx context.Context, d *schema.ResourceData, me
 					"cluster project is only supported from ArgoCD %s onwards",
 					featureVersionConstraintsMap[featureProjectScopedClusters].String()),
 				Detail: "See https://argo-cd.readthedocs.io/en/stable/user-guide/projects/#project-scoped-repositories-and-clusters",
+			},
+		}
+	}
+
+	featureClusterMetadataSupported, err := server.isFeatureSupported(featureClusterMetadata)
+	if err != nil {
+		return []diag.Diagnostic{
+			{
+				Severity: diag.Error,
+				Summary:  "feature not supported",
+				Detail:   err.Error(),
+			},
+		}
+	}
+
+	if !featureClusterMetadataSupported && (len(cluster.Annotations) != 0 || len(cluster.Labels) != 0) {
+		return []diag.Diagnostic{
+			{
+				Severity: diag.Error,
+				Summary: fmt.Sprintf(
+					"cluster metadata is only supported from ArgoCD %s onwards",
+					featureVersionConstraintsMap[featureClusterMetadata].String()),
 			},
 		}
 	}

--- a/argocd/structure_cluster.go
+++ b/argocd/structure_cluster.go
@@ -126,6 +126,11 @@ func flattenCluster(cluster *application.Cluster, d *schema.ResourceData) error 
 		"config":     flattenClusterConfig(cluster.Config, d),
 		"project":    cluster.Project,
 	}
+	if len(cluster.Annotations) != 0 || len(cluster.Labels) != 0 {
+		// The generic flattenMetadata function can not be used since the Cluster
+		// object does not actually have ObjectMeta, just label and annotation maps
+		r["metadata"] = flattenClusterMetadata(cluster.Annotations, cluster.Labels)
+	}
 	if cluster.Shard != nil {
 		r["shard"] = convertInt64PointerToString(cluster.Shard)
 	}
@@ -201,4 +206,13 @@ func flattenClusterConfigExecProviderConfig(epc *application.ExecProviderConfig)
 		}
 	}
 	return
+}
+
+func flattenClusterMetadata(annotations, labels map[string]string) []map[string]interface{} {
+	return []map[string]interface{}{
+		{
+			"annotations": annotations,
+			"labels":      labels,
+		},
+	}
 }


### PR DESCRIPTION
Looks like cluster metadata is not read and does not import properly in the current release.

In addition to fixing that issue this also adds an acceptance and version constraint for cluster metadata.