### PR TITLE
fix: constant orphaned changes if not specified & crash

### DIFF
--- a/argocd/resource_argocd_project_test.go
+++ b/argocd/resource_argocd_project_test.go
@@ -64,6 +64,16 @@ func TestAccArgoCDProject(t *testing.T) {
 					// TODO: check all possible attributes
 				),
 			},
+			{
+				Config: testAccArgoCDProjectSimpleWithoutOrph(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(
+						"argocd_project.simple",
+						"metadata.0.uid",
+						// TODO: check all possible attributes
+					),
+				),
+			},
 		},
 	})
 }
@@ -197,6 +207,33 @@ resource "argocd_project" "simple" {
     ]
   }
 }
+	`, name)
+}
+
+func testAccArgoCDProjectSimpleWithoutOrph(name string) string {
+	return fmt.Sprintf(`
+  resource "argocd_project" "simple" {
+    metadata {
+      name      = "%s"
+      namespace = "argocd"
+      labels = {
+        acceptance = "true"
+      }
+      annotations = {
+        "this.is.a.really.long.nested.key" = "yes, really!"
+      }
+    }
+  
+    spec {
+      description  = "simple project"
+      source_repos = ["*"]
+  
+      destination {
+        name      = "anothercluster"
+        namespace = "bar"
+      }
+    }
+  }
 	`, name)
 }
 

--- a/argocd/resource_argocd_project_test.go
+++ b/argocd/resource_argocd_project_test.go
@@ -94,7 +94,6 @@ func TestAccArgoCDProject_tokensCoexistence(t *testing.T) {
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				ExpectNonEmptyPlan: true,
 				Config: testAccArgoCDProjectCoexistenceWithTokenResource(
 					"test-acc-"+acctest.RandString(10),
 					4,

--- a/argocd/resource_argocd_project_test.go
+++ b/argocd/resource_argocd_project_test.go
@@ -65,7 +65,17 @@ func TestAccArgoCDProject(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccArgoCDProjectSimpleWithoutOrph(name),
+				Config: testAccArgoCDProjectSimpleWithoutOrphaned(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(
+						"argocd_project.simple",
+						"metadata.0.uid",
+						// TODO: check all possible attributes
+					),
+				),
+			},
+			{
+				Config: testAccArgoCDProjectSimpleWithEmptyOrphaned(name),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(
 						"argocd_project.simple",
@@ -210,7 +220,7 @@ resource "argocd_project" "simple" {
 	`, name)
 }
 
-func testAccArgoCDProjectSimpleWithoutOrph(name string) string {
+func testAccArgoCDProjectSimpleWithoutOrphaned(name string) string {
 	return fmt.Sprintf(`
   resource "argocd_project" "simple" {
     metadata {
@@ -232,6 +242,34 @@ func testAccArgoCDProjectSimpleWithoutOrph(name string) string {
         name      = "anothercluster"
         namespace = "bar"
       }
+    }
+  }
+	`, name)
+}
+
+func testAccArgoCDProjectSimpleWithEmptyOrphaned(name string) string {
+	return fmt.Sprintf(`
+  resource "argocd_project" "simple" {
+    metadata {
+      name      = "%s"
+      namespace = "argocd"
+      labels = {
+        acceptance = "true"
+      }
+      annotations = {
+        "this.is.a.really.long.nested.key" = "yes, really!"
+      }
+    }
+  
+    spec {
+      description  = "simple project"
+      source_repos = ["*"]
+  
+      destination {
+        name      = "anothercluster"
+        namespace = "bar"
+      }
+      orphaned_resources { }
     }
   }
 	`, name)

--- a/argocd/structure_project.go
+++ b/argocd/structure_project.go
@@ -63,9 +63,10 @@ func expandProjectSpec(d *schema.ResourceData) (
 		}
 	}
 	if v, ok := s["orphaned_resources"]; ok {
-		spec.OrphanedResources = &application.OrphanedResourcesMonitorSettings{}
 		orphanedResources := v.([]interface{})
 		if len(orphanedResources) > 0 {
+			spec.OrphanedResources = &application.OrphanedResourcesMonitorSettings{}
+
 			if _warn, _ok := orphanedResources[0].(map[string]interface{})["warn"]; _ok {
 				warn := _warn.(bool)
 				spec.OrphanedResources.Warn = &warn

--- a/argocd/structure_project.go
+++ b/argocd/structure_project.go
@@ -3,6 +3,7 @@ package argocd
 import (
 	"encoding/json"
 	"fmt"
+
 	application "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -67,13 +68,15 @@ func expandProjectSpec(d *schema.ResourceData) (
 		if len(orphanedResources) > 0 {
 			spec.OrphanedResources = &application.OrphanedResourcesMonitorSettings{}
 
-			if _warn, _ok := orphanedResources[0].(map[string]interface{})["warn"]; _ok {
-				warn := _warn.(bool)
-				spec.OrphanedResources.Warn = &warn
-			}
-			if _ignore, _ok := orphanedResources[0].(map[string]interface{})["ignore"]; _ok {
-				ignore := expandOrphanedResourcesIgnore(_ignore.(*schema.Set))
-				spec.OrphanedResources.Ignore = ignore
+			if orphanedResources[0] != nil {
+				if _warn, _ok := orphanedResources[0].(map[string]interface{})["warn"]; _ok {
+					warn := _warn.(bool)
+					spec.OrphanedResources.Warn = &warn
+				}
+				if _ignore, _ok := orphanedResources[0].(map[string]interface{})["ignore"]; _ok {
+					ignore := expandOrphanedResourcesIgnore(_ignore.(*schema.Set))
+					spec.OrphanedResources.Ignore = ignore
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Resolves #105 & #104 

To be on par with the API surface of Argo CD, "orphaned resources monitoring" will be only enabled if it is explicitly declared. Monitoring enabled because of the previous default behavior will be detected as a removal on next apply.

This is a **BREAKING CHANGE** with the current version :

<table>
<tr>
	<td>"Orphaned resources" block specified
	<td> Current version
	<td> This PR
<tr>
	<td> Yes
	<td> Enables monitoring
	<td> Enables monitoring
<tr>
	<td> No
	<td> Enables monitoring
	<td> Disables monitoring
</table>