### PR TITLE
fix(auth): allow interactive auth with k8s block

### DIFF
--- a/argocd/provider.go
+++ b/argocd/provider.go
@@ -262,6 +262,7 @@ func initApiClient(d *schema.ResourceData) (
 		if v, ok := k8sGetOk(d, "exec"); ok {
 			exec := &clientcmdapi.ExecConfig{}
 			if spec, ok := v.([]interface{})[0].(map[string]interface{}); ok {
+				exec.InteractiveMode = clientcmdapi.IfAvailableExecInteractiveMode
 				exec.APIVersion = spec["api_version"].(string)
 				exec.Command = spec["command"].(string)
 				exec.Args = expandStringSlice(spec["args"].([]interface{}))


### PR DESCRIPTION
Fixes #151 (cf https://github.com/kubernetes/client-go/blob/37ed584bedcad175bc0af93c02c356e4998dbeb9/tools/clientcmd/api/types.go#L249-L259)