### PR TITLE
fix: wrong default value for revision_history_limit in argocd_application resource

### DIFF
--- a/argocd/schema_application.go
+++ b/argocd/schema_application.go
@@ -392,6 +392,7 @@ func applicationSpecSchema() *schema.Schema {
 				"revision_history_limit": {
 					Type:     schema.TypeInt,
 					Optional: true,
+					Default:  10,
 				},
 			},
 		},


### PR DESCRIPTION
Make argocd_application.revision_history_limit default value to 10, as stated by documentation (fixes #160)

`(Optional) This limits the number of items kept in the apps revision history. This should only be changed in exceptional circumstances. Setting to zero will store no history. This will reduce storage used. Increasing will increase the space used to store the history, so we do not recommend increasing it. Default is 10.`