### PR TITLE
docs: add missing bearer_token config

### DIFF
--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -85,6 +85,7 @@ resource "argocd_cluster" "gke" {
   name   = "gke"
 
   config {
+    bearer_token = data.kubernetes_secret.argocd_manager.data["token"]
     tls_client_config {
       ca_data      = base64decode(data.google_container_cluster.cluster.master_auth.0.cluster_ca_certificate)
     }


### PR DESCRIPTION
Following the "[Example Usage - GCP GKE cluster](https://registry.terraform.io/providers/oboukili/argocd/latest/docs/resources/cluster#example-usage---gcp-gke-cluster)" guide cluster creation kept failing, Comparing clusters created through the provider with existing clusters showed that the bearer_token config was missing. 

I'm thinking its a mistake since the kubernetes_secret data source is already in the example but unused. 

If for some reason this is by design, or i missed some "before you make PR's here please read and do this and that section" i apologize and the PR can be closed.  