### PR TITLE
fix: Allow cluster name to be omitted & ensure unique cluster on creation

### DIFF
--- a/argocd/provider.go
+++ b/argocd/provider.go
@@ -27,6 +27,9 @@ var apiClientConnOpts apiclient.ClientOptions
 // Used to handle concurrent access to ArgoCD common configuration
 var tokenMutexConfiguration = &sync.RWMutex{}
 
+// Used to handle concurrent access to ArgoCD clusters
+var tokenMutexClusters = &sync.RWMutex{}
+
 // Used to handle concurrent access to each ArgoCD project
 var tokenMutexProjectMap = make(map[string]*sync.RWMutex, 0)
 

--- a/argocd/resource_argocd_cluster.go
+++ b/argocd/resource_argocd_cluster.go
@@ -103,7 +103,9 @@ func resourceArgoCDClusterCreate(ctx context.Context, d *schema.ResourceData, me
 			},
 		}
 	}
-	if c.Name != "" {
+
+	// Check if the name has been defaulted to server (when omitted)
+	if c.Name != "" && c.Name != c.Server {
 		d.SetId(fmt.Sprintf("%s/%s", c.Server, c.Name))
 	} else {
 		d.SetId(c.Server)

--- a/argocd/resource_argocd_cluster.go
+++ b/argocd/resource_argocd_cluster.go
@@ -92,8 +92,44 @@ func resourceArgoCDClusterCreate(ctx context.Context, d *schema.ResourceData, me
 		}
 	}
 
+	// Cluster are unique by "server address" so we should check there is no existing cluster with this address before
+	tokenMutexClusters.RLock()
+	existingClusters, err := client.List(ctx, &clusterClient.ClusterQuery{
+		Id: &clusterClient.ClusterID{
+			Type:  "server",
+			Value: cluster.Server, // TODO: not used by backend, upstream bug ?
+		},
+	})
+	tokenMutexClusters.RUnlock()
+	if err != nil {
+		return []diag.Diagnostic{
+			{
+				Severity: diag.Error,
+				Summary:  fmt.Sprintf("could not get current clusters list:  %s", err),
+				Detail:   err.Error(),
+			},
+		}
+	}
+
+	rtrimmedServer := strings.TrimRight(cluster.Server, "/")
+	if err == nil && len(existingClusters.Items) > 0 {
+		for _, existingCluster := range existingClusters.Items {
+			if rtrimmedServer == strings.TrimRight(existingCluster.Server, "/") {
+				return []diag.Diagnostic{
+					{
+						Severity: diag.Error,
+						Summary:  fmt.Sprintf("cluster with server address %s already exists", cluster.Server),
+					},
+				}
+			}
+		}
+	}
+
+	tokenMutexClusters.Lock()
 	c, err := client.Create(ctx, &clusterClient.ClusterCreateRequest{
 		Cluster: cluster, Upsert: true})
+	tokenMutexClusters.Unlock()
+
 	if err != nil {
 		return []diag.Diagnostic{
 			{
@@ -125,7 +161,11 @@ func resourceArgoCDClusterRead(ctx context.Context, d *schema.ResourceData, meta
 		}
 	}
 	client := *server.ClusterClient
+
+	tokenMutexClusters.RLock()
 	c, err := client.Get(ctx, getClusterQueryFromID(d))
+	tokenMutexClusters.RUnlock()
+
 	if err != nil {
 		if strings.Contains(err.Error(), "NotFound") {
 			d.SetId("")
@@ -220,7 +260,10 @@ func resourceArgoCDClusterUpdate(ctx context.Context, d *schema.ResourceData, me
 		}
 	}
 
+	tokenMutexClusters.Lock()
 	_, err = client.Update(ctx, &clusterClient.ClusterUpdateRequest{Cluster: cluster})
+	tokenMutexClusters.Unlock()
+
 	if err != nil {
 		if strings.Contains(err.Error(), "NotFound") {
 			d.SetId("")
@@ -250,7 +293,10 @@ func resourceArgoCDClusterDelete(ctx context.Context, d *schema.ResourceData, me
 		}
 	}
 	client := *server.ClusterClient
+	tokenMutexClusters.Lock()
 	_, err := client.Delete(ctx, getClusterQueryFromID(d))
+	tokenMutexClusters.Unlock()
+
 	if err != nil {
 		if strings.Contains(err.Error(), "NotFound") {
 			d.SetId("")

--- a/argocd/resource_argocd_cluster_test.go
+++ b/argocd/resource_argocd_cluster_test.go
@@ -2,6 +2,7 @@ package argocd
 
 import (
 	"fmt"
+	"regexp"
 	"runtime"
 	"testing"
 
@@ -257,6 +258,104 @@ func TestAccArgoCDCluster_metadata(t *testing.T) {
 	})
 }
 
+func TestAccArgoCDCluster_uniqueByServerEvenWithDifferentNames(t *testing.T) {
+	name := acctest.RandString(10)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckFeatureSupported(t, featureProjectScopedClusters) },
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccArgoCDClusterTwiceWithSameServer(name, name+"d"),
+				ExpectError: regexp.MustCompile("cluster with server address .* already exists"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"argocd_cluster.cluster_one",
+						"info.0.connection_state.0.status",
+						"Successful",
+					),
+					resource.TestCheckResourceAttr(
+						"argocd_cluster.cluster_one",
+						"config.0.tls_client_config.0.insecure",
+						"true",
+					),
+					resource.TestCheckResourceAttr(
+						"argocd_cluster.cluster_one",
+						"name",
+						name,
+					),
+				),
+			},
+		},
+	})
+}
+
+func TestAccArgoCDCluster_uniqueByServer(t *testing.T) {
+	name := acctest.RandString(10)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckFeatureSupported(t, featureProjectScopedClusters) },
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccArgoCDClusterTwiceWithSameServerNoNames(),
+				ExpectError: regexp.MustCompile("cluster with server address .* already exists"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"argocd_cluster.cluster_one",
+						"info.0.connection_state.0.status",
+						"Successful",
+					),
+					resource.TestCheckResourceAttr(
+						"argocd_cluster.cluster_one",
+						"config.0.tls_client_config.0.insecure",
+						"true",
+					),
+					resource.TestCheckResourceAttr(
+						"argocd_cluster.cluster_one",
+						"name",
+						name,
+					),
+				),
+			},
+		},
+	})
+}
+
+func TestAccArgoCDCluster_uniqueByServerTrimmed(t *testing.T) {
+	name := acctest.RandString(10)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckFeatureSupported(t, featureProjectScopedClusters) },
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccArgoCDClusterTwiceWithSameServerNoNamesTrimmed(
+					"https://kubernetes.default.svc.cluster.local",
+					"https://kubernetes.default.svc.cluster.local/"),
+				ExpectError: regexp.MustCompile("cluster with server address .* already exists"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"argocd_cluster.cluster_one",
+						"info.0.connection_state.0.status",
+						"Successful",
+					),
+					resource.TestCheckResourceAttr(
+						"argocd_cluster.cluster_one",
+						"config.0.tls_client_config.0.insecure",
+						"true",
+					),
+					resource.TestCheckResourceAttr(
+						"argocd_cluster.cluster_one",
+						"name",
+						name,
+					),
+				),
+			},
+		},
+	})
+}
+
 func testAccArgoCDClusterBearerToken(clusterName string) string {
 	return fmt.Sprintf(`
 resource "argocd_cluster" "simple" {
@@ -350,6 +449,83 @@ resource "argocd_cluster" "cluster_metadata" {
   }
 }
 `
+}
+
+func testAccArgoCDClusterTwiceWithSameServer(clusterName, clusterName2 string) string {
+	return fmt.Sprintf(`
+resource "argocd_cluster" "cluster_one" {
+  server = "https://kubernetes.default.svc.cluster.local"
+  name   = "%s"
+  config {
+    # Uses Kind's bootstrap token whose ttl is 24 hours after cluster bootstrap.
+    bearer_token = "abcdef.0123456789abcdef"
+    tls_client_config {
+      insecure = true
+    }
+  }
+}
+resource "argocd_cluster" "cluster_two" {
+  server = "https://kubernetes.default.svc.cluster.local"
+  name   = "%s"
+  config {
+    # Uses Kind's bootstrap token whose ttl is 24 hours after cluster bootstrap.
+    bearer_token = "abcdef.0123456789abcdef"
+    tls_client_config {
+      insecure = true
+    }
+  }
+}
+`, clusterName, clusterName2)
+}
+
+func testAccArgoCDClusterTwiceWithSameServerNoNames() string {
+	return `
+resource "argocd_cluster" "cluster_one" {
+  server = "https://kubernetes.default.svc.cluster.local"
+  config {
+    # Uses Kind's bootstrap token whose ttl is 24 hours after cluster bootstrap.
+    bearer_token = "abcdef.0123456789abcdef"
+    tls_client_config {
+      insecure = true
+    }
+  }
+}
+resource "argocd_cluster" "cluster_two" {
+  server = "https://kubernetes.default.svc.cluster.local"
+  config {
+    # Uses Kind's bootstrap token whose ttl is 24 hours after cluster bootstrap.
+    bearer_token = "abcdef.0123456789abcdef"
+    tls_client_config {
+      insecure = true
+    }
+  }
+}
+`
+}
+
+func testAccArgoCDClusterTwiceWithSameServerNoNamesTrimmed(server, server2 string) string {
+	return fmt.Sprintf(`
+resource "argocd_cluster" "cluster_one" {
+  server = "%s"
+  config {
+    # Uses Kind's bootstrap token whose ttl is 24 hours after cluster bootstrap.
+    bearer_token = "abcdef.0123456789abcdef"
+    tls_client_config {
+      insecure = true
+    }
+  }
+}
+resource "argocd_cluster" "cluster_two" {
+  server = "%s"
+  config {
+    # Uses Kind's bootstrap token whose ttl is 24 hours after cluster bootstrap.
+    bearer_token = "abcdef.0123456789abcdef"
+    tls_client_config {
+      insecure = true
+    }
+  }
+}
+`, server, server2)
 }
 
 func testAccArgoCDClusterMetadata_addLabels(clusterName string) string {

--- a/argocd/schema_cluster.go
+++ b/argocd/schema_cluster.go
@@ -10,6 +10,17 @@ func clusterSchema() map[string]*schema.Schema {
 			Type:        schema.TypeString,
 			Description: "Name of the cluster. If omitted, will use the server address",
 			Optional:    true,
+			DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+				if k == "name" {
+					name, nameOk := d.GetOk("name")
+					server, serverOk := d.GetOk("server")
+					// Actual value is same as 'server' but not explicitly set
+					if nameOk && serverOk && name == server && old == server && new == "" {
+						return true
+					}
+				}
+				return false
+			},
 		},
 		"server": {
 			Type:        schema.TypeString,


### PR DESCRIPTION
* Name was already an optional property (defaulted to `server`) but made a weird `ID` = `server/name` (ex: https://kubernetes.default.svc.cluster.local/https://kubernetes.default.svc.cluster.local) which broke the ID parser on read and made further operations impossible.
Should fixes parts of #84 

* I also noticed while testing clusters that if you declare 2 clusters with the same server adress, they will manage the same item on k8s and overwrite each other properties (since we have `upsert: true`). 
I made a few tests on the REST api to make sure I got the same results :
```json
{
  "config": {
    "bearerToken": "abcdef.0123456789abcdef",
    "tlsClientConfig": { "insecure": true }
  },
  "name": "hello",
  "server": "https://kubernetes.default.svc.cluster.local"
}
```
POST => 200 OK

```diff
{
  "config": {
    "bearerToken": "abcdef.0123456789abcdef",
    "tlsClientConfig": { "insecure": true }
  },
-  "name": "hello",
+ "name": "hello2",
  "server": "https://kubernetes.default.svc.cluster.local"
}
```
POST => 400 
```json
{
    "error": "existing cluster spec is different; use upsert flag to force update; difference in keys \"ID,Name\"",
    "code": 3,
    "message": "existing cluster spec is different; use upsert flag to force update; difference in keys \"ID,Name\""
}
```

I added a check before cluster creation to make sure the server was not already created (and a mutex to avoid concurrent create in the same apply)

Again, a bit of "not sure why in Go", I used `client.List` for this check because I got **permission denied** when using `client.Get` (which should have been better):
```go
existingCluster, err := client.Get(ctx, &clusterClient.ClusterQuery{
		Server: cluster.Server,
})
```
