### PR TITLE
feat(application): add SkipCrds to helm source

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        argocd_version: ["v2.2.5", "v2.1.10"]
+        argocd_version: ["v2.3.0", "v2.2.5", "v2.1.10"]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v1

--- a/argocd/features.go
+++ b/argocd/features.go
@@ -27,6 +27,7 @@ const (
 	featureProjectScopedClusters
 	featureClusterMetadata
 	featureRepositoryCertificates
+	featureApplicationHelmSkipCrds
 )
 
 var (
@@ -38,6 +39,7 @@ var (
 		featureProjectScopedClusters:       semver.MustParse("2.2.0"),
 		featureClusterMetadata:             semver.MustParse("2.2.0"),
 		featureRepositoryCertificates:      semver.MustParse("1.2.0"),
+		featureApplicationHelmSkipCrds:     semver.MustParse("2.3.0"),
 	}
 )
 

--- a/argocd/provider_test.go
+++ b/argocd/provider_test.go
@@ -43,6 +43,7 @@ func testAccPreCheck(t *testing.T) {
 	}
 }
 
+// Skip test if feature is not supported
 func testAccPreCheckFeatureSupported(t *testing.T, feature int) {
 	v := os.Getenv("ARGOCD_VERSION")
 	if v == "" {
@@ -61,6 +62,7 @@ func testAccPreCheckFeatureSupported(t *testing.T, feature int) {
 	}
 }
 
+// Skip test if feature is supported
 func testAccPreCheckFeatureNotSupported(t *testing.T, feature int) {
 	v := os.Getenv("ARGOCD_VERSION")
 	if v == "" {

--- a/argocd/provider_test.go
+++ b/argocd/provider_test.go
@@ -60,3 +60,21 @@ func testAccPreCheckFeatureSupported(t *testing.T, feature int) {
 		t.Skipf("version %s does not support feature", v)
 	}
 }
+
+func testAccPreCheckFeatureNotSupported(t *testing.T, feature int) {
+	v := os.Getenv("ARGOCD_VERSION")
+	if v == "" {
+		t.Skip("ARGOCD_VERSION must be set set for feature supported acceptance tests")
+	}
+	serverVersion, err := semver.NewVersion(v)
+	if err != nil {
+		t.Fatalf("could not parse ARGOCD_VERSION as semantic version: %s", v)
+	}
+	versionConstraint, ok := featureVersionConstraintsMap[feature]
+	if !ok {
+		t.Fatal("feature constraint is not handled by the provider")
+	}
+	if i := versionConstraint.Compare(serverVersion); i != 1 {
+		t.Skipf("version %s does not support feature", v)
+	}
+}

--- a/argocd/resource_argocd_application.go
+++ b/argocd/resource_argocd_application.go
@@ -3,9 +3,10 @@ package argocd
 import (
 	"context"
 	"fmt"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"strings"
 	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	applicationClient "github.com/argoproj/argo-cd/v2/pkg/apiclient/application"
 	application "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
@@ -27,7 +28,7 @@ func resourceArgoCDApplication() *schema.Resource {
 		},
 		Schema: map[string]*schema.Schema{
 			"metadata": metadataSchema("applications.argoproj.io"),
-			"spec":     applicationSpecSchema(),
+			"spec":     applicationSpecSchemaV1(),
 			"wait": {
 				Type:        schema.TypeBool,
 				Description: "Upon application creation or update, wait for application health/sync status to be healthy/Synced, upon application deletion, wait for application to be removed, when set to true.",
@@ -39,6 +40,14 @@ func resourceArgoCDApplication() *schema.Resource {
 				Description: "Whether to applying cascading deletion when application is removed.",
 				Optional:    true,
 				Default:     true,
+			},
+		},
+		SchemaVersion: 1,
+		StateUpgraders: []schema.StateUpgrader{
+			{
+				Type:    resourceArgoCDApplicationV0().CoreConfigSchema().ImpliedType(),
+				Upgrade: resourceArgoCDApplicationStateUpgradeV0,
+				Version: 0,
 			},
 		},
 		Timeouts: &schema.ResourceTimeout{

--- a/argocd/resource_argocd_application.go
+++ b/argocd/resource_argocd_application.go
@@ -22,7 +22,6 @@ func resourceArgoCDApplication() *schema.Resource {
 		ReadContext:   resourceArgoCDApplicationRead,
 		UpdateContext: resourceArgoCDApplicationUpdate,
 		DeleteContext: resourceArgoCDApplicationDelete,
-		// TODO: add importer acceptance tests
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},

--- a/argocd/resource_argocd_application.go
+++ b/argocd/resource_argocd_application.go
@@ -148,6 +148,31 @@ func resourceArgoCDApplicationCreate(ctx context.Context, d *schema.ResourceData
 		}
 	}
 
+	featureApplicationHelmSkipCrdsSupported, err := server.isFeatureSupported(featureApplicationHelmSkipCrds)
+	if err != nil {
+		return []diag.Diagnostic{
+			{
+				Severity: diag.Error,
+				Summary:  "feature not supported",
+				Detail:   err.Error(),
+			},
+		}
+	}
+
+	if !featureApplicationHelmSkipCrdsSupported {
+		_, skipCrdsOk := d.GetOk("spec.0.source.0.helm.0.skip_crds")
+		if skipCrdsOk {
+			return []diag.Diagnostic{
+				{
+					Severity: diag.Error,
+					Summary: fmt.Sprintf(
+						"application helm skip_crds is only supported from ArgoCD %s onwards",
+						featureVersionConstraintsMap[featureApplicationHelmSkipCrds].String()),
+				},
+			}
+		}
+	}
+
 	app, err = c.Create(ctx, &applicationClient.ApplicationCreateRequest{
 		Application: application.Application{
 
@@ -327,6 +352,31 @@ func resourceArgoCDApplicationUpdate(ctx context.Context, d *schema.ResourceData
 						featureVersionConstraintsMap[featureIgnoreDiffJQPathExpressions].String()),
 					Detail: err.Error(),
 				},
+			}
+		}
+
+		featureApplicationHelmSkipCrdsSupported, err := server.isFeatureSupported(featureApplicationHelmSkipCrds)
+		if err != nil {
+			return []diag.Diagnostic{
+				{
+					Severity: diag.Error,
+					Summary:  "feature not supported",
+					Detail:   err.Error(),
+				},
+			}
+		}
+
+		if !featureApplicationHelmSkipCrdsSupported {
+			_, skipCrdsOk := d.GetOk("spec.0.source.0.helm.0.skip_crds")
+			if skipCrdsOk {
+				return []diag.Diagnostic{
+					{
+						Severity: diag.Error,
+						Summary: fmt.Sprintf(
+							"application helm skip_crds is only supported from ArgoCD %s onwards",
+							featureVersionConstraintsMap[featureApplicationHelmSkipCrds].String()),
+					},
+				}
 			}
 		}
 

--- a/argocd/resource_argocd_application_test.go
+++ b/argocd/resource_argocd_application_test.go
@@ -679,7 +679,7 @@ func TestProvider_headers(t *testing.T) {
 	})
 }
 
-func TestAccArgoCDApplication_SkipCrds_NotSupported(t *testing.T) {
+func TestAccArgoCDApplication_SkipCrds_NotSupported_On_OlderVersions(t *testing.T) {
 	name := acctest.RandomWithPrefix("test-acc-crds")
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/argocd/resource_argocd_application_test.go
+++ b/argocd/resource_argocd_application_test.go
@@ -42,6 +42,12 @@ ingress:
 					"metadata.0.uid",
 				),
 			},
+			{
+				ResourceName:            "argocd_application.simple",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"wait", "cascade"},
+			},
 			// Check with the same name for rapid application recreation robustness
 			{
 				Config: testAccArgoCDApplicationSimple(commonName),
@@ -93,6 +99,12 @@ ingress:
 				),
 			},
 			{
+				ResourceName:            "argocd_application.helm",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"wait", "cascade", "metadata.0.generation", "metadata.0.resource_version"},
+			},
+			{
 				Config: testAccArgoCDApplicationKustomize(
 					acctest.RandomWithPrefix("test-acc")),
 				Check: resource.ComposeTestCheckFunc(
@@ -111,6 +123,12 @@ ingress:
 						"-bar",
 					),
 				),
+			},
+			{
+				ResourceName:            "argocd_application.kustomize",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"wait", "cascade", "metadata.0.generation", "metadata.0.resource_version"},
 			},
 			{
 				Config: testAccArgoCDApplicationDirectory(
@@ -173,6 +191,12 @@ ingress:
 				),
 			},
 			{
+				ResourceName:            "argocd_application.directory",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"wait", "cascade", "metadata.0.generation", "metadata.0.resource_version"},
+			},
+			{
 				Config: testAccArgoCDApplicationSyncPolicy(
 					acctest.RandomWithPrefix("test-acc")),
 				Check: resource.ComposeTestCheckFunc(
@@ -218,6 +242,12 @@ ingress:
 				),
 			},
 			{
+				ResourceName:            "argocd_application.sync_policy",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"wait", "cascade", "metadata.0.generation", "metadata.0.resource_version"},
+			},
+			{
 				Config: testAccArgoCDApplicationIgnoreDifferences(
 					acctest.RandomWithPrefix("test-acc")),
 				Check: resource.ComposeTestCheckFunc(
@@ -236,6 +266,12 @@ ingress:
 						"apps",
 					),
 				),
+			},
+			{
+				ResourceName:            "argocd_application.ignore_differences",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"wait", "cascade"},
 			},
 			{
 				SkipFunc: testAccSkipFeatureIgnoreDiffJQPathExpressions,
@@ -257,6 +293,12 @@ ingress:
 						".spec.template.spec.metadata.labels.somelabel",
 					),
 				),
+			},
+			{
+				ResourceName:            "argocd_application.ignore_differences_jqpe",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"wait", "cascade"},
 			},
 			{
 				Config: testAccArgoCDApplicationSimpleRevisionHistory(commonName, revisionHistoryLimit),

--- a/argocd/resource_argocd_application_test.go
+++ b/argocd/resource_argocd_application_test.go
@@ -683,7 +683,7 @@ func TestAccArgoCDApplication_SkipCrds_NotSupported(t *testing.T) {
 	name := acctest.RandomWithPrefix("test-acc-crds")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckFeatureNotSupported(t, featureApplicationHelmSkipCrds) },
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
 			// Create tests
@@ -1668,24 +1668,6 @@ func testAccSkipFeatureIgnoreDiffJQPathExpressions() (bool, error) {
 		return false, err
 	}
 	featureSupported, err := server.isFeatureSupported(featureIgnoreDiffJQPathExpressions)
-	if err != nil {
-		return false, err
-	}
-	if !featureSupported {
-		return true, nil
-	}
-	return false, nil
-}
-
-func testAccSkipFeatureHelmSkipCrds() (bool, error) {
-	p, _ := testAccProviders["argocd"]()
-	_ = p.Configure(context.Background(), &terraform.ResourceConfig{})
-	server := p.Meta().(*ServerInterface)
-	err := server.initClients()
-	if err != nil {
-		return false, err
-	}
-	featureSupported, err := server.isFeatureSupported(featureApplicationHelmSkipCrds)
 	if err != nil {
 		return false, err
 	}

--- a/argocd/resource_argocd_application_test.go
+++ b/argocd/resource_argocd_application_test.go
@@ -1599,7 +1599,7 @@ resource "argocd_application" "crds" {
     source {
 		repo_url        = "https://charts.bitnami.com/bitnami"
 		chart           = "redis"
-		target_revision = "15.3.0"
+		target_revision = "16.9.11"
 		helm {
 		  parameter {
 			name  = "image.tag"
@@ -1637,7 +1637,7 @@ resource "argocd_application" "crds" {
     source {
 		repo_url        = "https://charts.bitnami.com/bitnami"
 		chart           = "redis"
-		target_revision = "15.3.0"
+		target_revision = "16.9.11"
 		helm {
 		  parameter {
 			name  = "image.tag"

--- a/argocd/resource_argocd_cluster.go
+++ b/argocd/resource_argocd_cluster.go
@@ -16,7 +16,6 @@ func resourceArgoCDCluster() *schema.Resource {
 		ReadContext:   resourceArgoCDClusterRead,
 		UpdateContext: resourceArgoCDClusterUpdate,
 		DeleteContext: resourceArgoCDClusterDelete,
-		// TODO: add importer tests
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},

--- a/argocd/resource_argocd_cluster_test.go
+++ b/argocd/resource_argocd_cluster_test.go
@@ -48,6 +48,13 @@ func TestAccArgoCDCluster(t *testing.T) {
 					),
 				),
 			},
+			//TODO: not working on CI every time
+			// {
+			// 	ResourceName:            "argocd_cluster.simple",
+			// 	ImportState:             true,
+			// 	ImportStateVerify:       true,
+			// 	ImportStateVerifyIgnore: []string{"config.0.bearer_token", "config.0.tls_client_config"},
+			// },
 			{
 				Config: testAccArgoCDClusterTLSCertificate(t, acctest.RandString(10)),
 				Check: resource.ComposeTestCheckFunc(
@@ -97,6 +104,13 @@ func TestAccArgoCDCluster_projectScope(t *testing.T) {
 					),
 				),
 			},
+			//TODO: not working on CI every time
+			// {
+			// 	ResourceName:            "argocd_cluster.project_scope",
+			// 	ImportState:             true,
+			// 	ImportStateVerify:       true,
+			// 	ImportStateVerifyIgnore: []string{"config.0.bearer_token", "config.0.tls_client_config"},
+			// },
 		},
 	})
 }

--- a/argocd/resource_argocd_project.go
+++ b/argocd/resource_argocd_project.go
@@ -19,7 +19,6 @@ func resourceArgoCDProject() *schema.Resource {
 		ReadContext:   resourceArgoCDProjectRead,
 		UpdateContext: resourceArgoCDProjectUpdate,
 		DeleteContext: resourceArgoCDProjectDelete,
-		// TODO: add importer acceptance tests
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},

--- a/argocd/resource_argocd_project_test.go
+++ b/argocd/resource_argocd_project_test.go
@@ -53,6 +53,11 @@ func TestAccArgoCDProject(t *testing.T) {
 					"metadata.0.uid",
 				),
 			},
+			{
+				ResourceName:      "argocd_project.simple",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 			// Check with the same name for rapid project recreation robustness
 			{
 				Config: testAccArgoCDProjectSimple(name),
@@ -148,6 +153,11 @@ func TestAccArgoCDProjectUpdateAddRole(t *testing.T) {
 						"metadata.0.uid",
 					),
 				),
+			},
+			{
+				ResourceName:      "argocd_project.simple",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccArgoCDProjectSimpleWithRole(name),

--- a/argocd/resource_argocd_repository.go
+++ b/argocd/resource_argocd_repository.go
@@ -19,7 +19,6 @@ func resourceArgoCDRepository() *schema.Resource {
 		ReadContext:   resourceArgoCDRepositoryRead,
 		UpdateContext: resourceArgoCDRepositoryUpdate,
 		DeleteContext: resourceArgoCDRepositoryDelete,
-		// TODO: add importer acceptance tests
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},

--- a/argocd/resource_argocd_repository_credentials.go
+++ b/argocd/resource_argocd_repository_credentials.go
@@ -17,7 +17,6 @@ func resourceArgoCDRepositoryCredentials() *schema.Resource {
 		ReadContext:   resourceArgoCDRepositoryCredentialsRead,
 		UpdateContext: resourceArgoCDRepositoryCredentialsUpdate,
 		DeleteContext: resourceArgoCDRepositoryCredentialsDelete,
-		// TODO: add importer acceptance tests
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},

--- a/argocd/resource_argocd_repository_credentials_test.go
+++ b/argocd/resource_argocd_repository_credentials_test.go
@@ -33,6 +33,12 @@ func TestAccArgoCDRepositoryCredentials(t *testing.T) {
 				),
 			},
 			{
+				ResourceName:            "argocd_repository_credentials.simple",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"ssh_private_key"},
+			},
+			{
 				Config: testAccArgoCDRepositoryCredentialsRepositoryCoexistence(),
 				Check: testCheckMultipleResourceAttr(
 					"argocd_repository.private",

--- a/argocd/resource_argocd_repository_test.go
+++ b/argocd/resource_argocd_repository_test.go
@@ -23,12 +23,22 @@ func TestAccArgoCDRepository(t *testing.T) {
 				),
 			},
 			{
+				ResourceName:      "argocd_repository.simple",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
 				Config: testAccArgoCDRepositoryHelm(),
 				Check: resource.TestCheckResourceAttr(
 					"argocd_repository.helm",
 					"connection_state_status",
 					"Successful",
 				),
+			},
+			{
+				ResourceName:      "argocd_repository.helm",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccArgoCDRepositoryPublicUsageInApplication(acctest.RandString(10)),
@@ -51,6 +61,12 @@ func TestAccArgoCDRepository(t *testing.T) {
 						"false",
 					),
 				),
+			},
+			{
+				ResourceName:            "argocd_repository.private",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"ssh_private_key"},
 			},
 			{
 				Config: testAccArgoCDRepositoryMultiplePrivateGitSSH(10),

--- a/argocd/schema_application.go
+++ b/argocd/schema_application.go
@@ -1,10 +1,417 @@
 package argocd
 
 import (
+	"context"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func applicationSpecSchema() *schema.Schema {
+func applicationSpecSchemaV0() *schema.Schema {
+	return &schema.Schema{
+		Type:        schema.TypeList,
+		MinItems:    1,
+		MaxItems:    1,
+		Description: "ArgoCD App application resource specs. Required attributes: destination, source.",
+		Required:    true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"destination": {
+					Type:     schema.TypeSet,
+					Required: true,
+					MinItems: 1,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"server": {
+								Type:     schema.TypeString,
+								Optional: true,
+							},
+							"namespace": {
+								Type:     schema.TypeString,
+								Required: true,
+							},
+							"name": {
+								Type:        schema.TypeString,
+								Optional:    true,
+								Description: "Name of the destination cluster which can be used instead of server.",
+							},
+						},
+					},
+				},
+				"source": {
+					Type:     schema.TypeList,
+					Required: true,
+					MinItems: 1,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"repo_url": {
+								Type:     schema.TypeString,
+								Required: true,
+							},
+							"path": {
+								Type:     schema.TypeString,
+								Optional: true,
+								// TODO: add validator to test path is not absolute
+							},
+							"target_revision": {
+								Type:     schema.TypeString,
+								Optional: true,
+							},
+							"chart": {
+								Type:     schema.TypeString,
+								Optional: true,
+							},
+							"helm": {
+								Type:     schema.TypeList,
+								MaxItems: 1,
+								MinItems: 1,
+								Optional: true,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"value_files": {
+											Type:     schema.TypeList,
+											Optional: true,
+											Elem: &schema.Schema{
+												Type: schema.TypeString,
+											},
+										},
+										"values": {
+											Type:     schema.TypeString,
+											Optional: true,
+										},
+										"parameter": {
+											Type:     schema.TypeSet,
+											Optional: true,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"name": {
+														Type:     schema.TypeString,
+														Optional: true,
+													},
+													"value": {
+														Type:     schema.TypeString,
+														Optional: true,
+													},
+													"force_string": {
+														Type:        schema.TypeBool,
+														Optional:    true,
+														Description: "force_string determines whether to tell Helm to interpret booleans and numbers as strings",
+													},
+												},
+											},
+										},
+										"release_name": {
+											Type:        schema.TypeString,
+											Description: "The Helm release name. If omitted it will use the application name",
+											Optional:    true,
+										},
+									},
+								},
+							},
+							"kustomize": {
+								Type:     schema.TypeList,
+								MaxItems: 1,
+								MinItems: 1,
+								Optional: true,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"name_prefix": {
+											Type:     schema.TypeString,
+											Optional: true,
+										},
+										"name_suffix": {
+											Type:     schema.TypeString,
+											Optional: true,
+										},
+										"version": {
+											Type:     schema.TypeString,
+											Optional: true,
+										},
+										"images": {
+											Type:     schema.TypeSet,
+											Optional: true,
+											Elem: &schema.Schema{
+												Type: schema.TypeString,
+											},
+										},
+										"common_labels": {
+											Type:         schema.TypeMap,
+											Optional:     true,
+											Elem:         &schema.Schema{Type: schema.TypeString},
+											ValidateFunc: validateMetadataLabels,
+										},
+										"common_annotations": {
+											Type:         schema.TypeMap,
+											Optional:     true,
+											Elem:         &schema.Schema{Type: schema.TypeString},
+											ValidateFunc: validateMetadataAnnotations,
+										},
+									},
+								},
+							},
+							"ksonnet": {
+								Type:     schema.TypeList,
+								MaxItems: 1,
+								MinItems: 1,
+								Optional: true,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"environment": {
+											Type:     schema.TypeString,
+											Optional: true,
+										},
+										"parameters": {
+											Type:     schema.TypeSet,
+											Optional: true,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"component": {
+														Type:     schema.TypeString,
+														Optional: true,
+													},
+													"name": {
+														Type:     schema.TypeString,
+														Optional: true,
+													},
+													"value": {
+														Type:     schema.TypeString,
+														Optional: true,
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+							"directory": {
+								Type: schema.TypeList,
+								DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+									// Avoid drift when recurse is explicitly set to false
+									// Also ignore the directory node if both recurse & jsonnet are not set or ignored
+									if k == "spec.0.source.0.directory.0.recurse" && old == "" && new == "false" {
+										return true
+									}
+									if k == "spec.0.source.0.directory.#" {
+										_, hasRecurse := d.GetOk("spec.0.source.0.directory.0.recurse")
+										_, hasJsonnet := d.GetOk("spec.0.source.0.directory.0.jsonnet")
+
+										if !hasJsonnet && !hasRecurse {
+											return true
+										}
+									}
+									return false
+								},
+								MaxItems: 1,
+								MinItems: 1,
+								Optional: true,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"recurse": {
+											Type:     schema.TypeBool,
+											Optional: true,
+										},
+										"jsonnet": {
+											Type:     schema.TypeList,
+											Optional: true,
+											MaxItems: 1,
+											MinItems: 1,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"ext_var": {
+														Type:     schema.TypeList,
+														Optional: true,
+														Elem: &schema.Resource{
+															Schema: map[string]*schema.Schema{
+																"name": {
+																	Type:     schema.TypeString,
+																	Optional: true,
+																},
+																"value": {
+																	Type:     schema.TypeString,
+																	Optional: true,
+																},
+																"code": {
+																	Type:     schema.TypeBool,
+																	Optional: true,
+																},
+															},
+														},
+													},
+													"tla": {
+														Type:     schema.TypeSet,
+														Optional: true,
+														Elem: &schema.Resource{
+															Schema: map[string]*schema.Schema{
+																"name": {
+																	Type:     schema.TypeString,
+																	Optional: true,
+																},
+																"value": {
+																	Type:     schema.TypeString,
+																	Optional: true,
+																},
+																"code": {
+																	Type:     schema.TypeBool,
+																	Optional: true,
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+							"plugin": {
+								Type:     schema.TypeList,
+								MaxItems: 1,
+								MinItems: 1,
+								Optional: true,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"name": {
+											Type:     schema.TypeString,
+											Optional: true,
+										},
+										"env": {
+											Type:     schema.TypeSet,
+											Optional: true,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"name": {
+														Type:     schema.TypeString,
+														Optional: true,
+													},
+													"value": {
+														Type:     schema.TypeString,
+														Optional: true,
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				"project": {
+					Type:        schema.TypeString,
+					Optional:    true,
+					Description: "The application project, defaults to 'default'",
+					Default:     "default",
+				},
+				"sync_policy": {
+					Type:     schema.TypeList,
+					Optional: true,
+					MaxItems: 1,
+					MinItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"automated": {
+								Type:     schema.TypeMap,
+								Optional: true,
+								Elem:     &schema.Schema{Type: schema.TypeBool},
+							},
+							"sync_options": {
+								Type:     schema.TypeList,
+								Optional: true,
+								Elem: &schema.Schema{
+									Type: schema.TypeString,
+									// TODO: add a validator
+								},
+							},
+							"retry": {
+								Type:     schema.TypeList,
+								MaxItems: 1,
+								Optional: true,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"limit": {
+											Type:        schema.TypeString,
+											Description: "Max number of allowed sync retries, as a string",
+											Optional:    true,
+										},
+										"backoff": {
+											Type:     schema.TypeMap,
+											Optional: true,
+											Elem:     &schema.Schema{Type: schema.TypeString},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				"ignore_difference": {
+					Type:     schema.TypeList,
+					Optional: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"group": {
+								Type:     schema.TypeString,
+								Optional: true,
+							},
+							"kind": {
+								Type:     schema.TypeString,
+								Optional: true,
+							},
+							"name": {
+								Type:     schema.TypeString,
+								Optional: true,
+							},
+							"namespace": {
+								Type:     schema.TypeString,
+								Optional: true,
+							},
+							"json_pointers": {
+								Type:     schema.TypeSet,
+								Set:      schema.HashString,
+								Optional: true,
+								Elem: &schema.Schema{
+									Type: schema.TypeString,
+								},
+							},
+							"jq_path_expressions": {
+								Type:     schema.TypeSet,
+								Set:      schema.HashString,
+								Optional: true,
+								Elem: &schema.Schema{
+									Type: schema.TypeString,
+								},
+							},
+						},
+					},
+				},
+				"info": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"name": {
+								Type:     schema.TypeString,
+								Optional: true,
+							},
+							"value": {
+								Type:     schema.TypeString,
+								Optional: true,
+							},
+						},
+					},
+				},
+				"revision_history_limit": {
+					Type:     schema.TypeInt,
+					Optional: true,
+					Default:  10,
+				},
+			},
+		},
+	}
+}
+
+func applicationSpecSchemaV1() *schema.Schema {
 	return &schema.Schema{
 		Type:        schema.TypeList,
 		MinItems:    1,
@@ -413,4 +820,37 @@ func applicationSpecSchema() *schema.Schema {
 			},
 		},
 	}
+}
+
+func resourceArgoCDApplicationV0() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"metadata": metadataSchema("appprojects.argoproj.io"),
+			"spec":     applicationSpecSchemaV0(),
+		},
+	}
+}
+
+func resourceArgoCDApplicationStateUpgradeV0(_ context.Context, rawState map[string]interface{}, _ interface{}) (map[string]interface{}, error) {
+	_spec, ok := rawState["spec"].([]interface{})
+	if !ok || len(_spec) == 0 {
+		return rawState, nil
+	}
+
+	spec := _spec[0].(map[string]interface{})
+	_source, ok := spec["source"].([]interface{})
+	if !ok || len(_source) == 0 {
+		return rawState, nil
+	}
+
+	source := _source[0].(map[string]interface{})
+	_helm, ok := source["helm"].([]interface{})
+	if !ok || len(_helm) == 0 {
+		return rawState, nil
+	}
+
+	helm := _helm[0].(map[string]interface{})
+	helm["skip_crds"] = false
+
+	return rawState, nil
 }

--- a/argocd/schema_application.go
+++ b/argocd/schema_application.go
@@ -105,6 +105,11 @@ func applicationSpecSchema() *schema.Schema {
 											Description: "The Helm release name. If omitted it will use the application name",
 											Optional:    true,
 										},
+										"skip_crds": {
+											Type:        schema.TypeBool,
+											Description: "Helm installs custom resource definitions in the crds folder by default if they are not existing. If needed, it is possible to skip the CRD installation step with this flag",
+											Optional:    true,
+										},
 									},
 								},
 							},

--- a/argocd/schema_application_test.go
+++ b/argocd/schema_application_test.go
@@ -12,7 +12,7 @@ func TestUpgradeSchemaApplication_V0V1_Default_SkipCrds(t *testing.T) {
 			"source": []interface{}{map[string]interface{}{
 				"repo_url":        "https://charts.bitnami.com/bitnami",
 				"chart":           "redis",
-				"target_revision": "15.3.0",
+				"target_revision": "16.9.11",
 
 				"helm": []interface{}{map[string]interface{}{
 					"release_name": "testing",
@@ -30,7 +30,7 @@ func TestUpgradeSchemaApplication_V0V1_Default_SkipCrds(t *testing.T) {
 			"source": []interface{}{map[string]interface{}{
 				"repo_url":        "https://charts.bitnami.com/bitnami",
 				"chart":           "redis",
-				"target_revision": "15.3.0",
+				"target_revision": "16.9.11",
 
 				"helm": []interface{}{map[string]interface{}{
 					"release_name": "testing",
@@ -57,7 +57,7 @@ func TestUpgradeSchemaApplication_V0V1_Default_SkipCrds_NoChange(t *testing.T) {
 			"source": []interface{}{map[string]interface{}{
 				"repo_url":        "https://charts.bitnami.com/bitnami",
 				"chart":           "redis",
-				"target_revision": "15.3.0",
+				"target_revision": "16.9.11",
 			}},
 			"destination": []interface{}{map[string]interface{}{
 				"server":    "https://kubernetes.default.svc",

--- a/argocd/schema_application_test.go
+++ b/argocd/schema_application_test.go
@@ -1,0 +1,74 @@
+package argocd
+
+import (
+	"context"
+	"reflect"
+	"testing"
+)
+
+func TestUpgradeSchemaApplication_V0V1_Default_SkipCrds(t *testing.T) {
+	v0 := map[string]interface{}{
+		"spec": []interface{}{map[string]interface{}{
+			"source": []interface{}{map[string]interface{}{
+				"repo_url":        "https://charts.bitnami.com/bitnami",
+				"chart":           "redis",
+				"target_revision": "15.3.0",
+
+				"helm": []interface{}{map[string]interface{}{
+					"release_name": "testing",
+				}},
+			}},
+			"destination": []interface{}{map[string]interface{}{
+				"server":    "https://kubernetes.default.svc",
+				"namespace": "default",
+			}}},
+		},
+	}
+
+	v1 := map[string]interface{}{
+		"spec": []interface{}{map[string]interface{}{
+			"source": []interface{}{map[string]interface{}{
+				"repo_url":        "https://charts.bitnami.com/bitnami",
+				"chart":           "redis",
+				"target_revision": "15.3.0",
+
+				"helm": []interface{}{map[string]interface{}{
+					"release_name": "testing",
+					"skip_crds":    false,
+				}},
+			}},
+			"destination": []interface{}{map[string]interface{}{
+				"server":    "https://kubernetes.default.svc",
+				"namespace": "default",
+			}}},
+		},
+	}
+
+	actual, _ := resourceArgoCDApplicationStateUpgradeV0(context.TODO(), v0, nil)
+
+	if !reflect.DeepEqual(v1, actual) {
+		t.Fatalf("\n\nexpected:\n\n%#v\n\ngot:\n\n%#v\n\n", v1, actual)
+	}
+}
+
+func TestUpgradeSchemaApplication_V0V1_Default_SkipCrds_NoChange(t *testing.T) {
+	v0 := map[string]interface{}{
+		"spec": []interface{}{map[string]interface{}{
+			"source": []interface{}{map[string]interface{}{
+				"repo_url":        "https://charts.bitnami.com/bitnami",
+				"chart":           "redis",
+				"target_revision": "15.3.0",
+			}},
+			"destination": []interface{}{map[string]interface{}{
+				"server":    "https://kubernetes.default.svc",
+				"namespace": "default",
+			}}},
+		},
+	}
+
+	actual, _ := resourceArgoCDApplicationStateUpgradeV0(context.TODO(), v0, nil)
+
+	if !reflect.DeepEqual(v0, actual) {
+		t.Fatalf("\n\nexpected:\n\n%#v\n\ngot:\n\n%#v\n\n", v0, actual)
+	}
+}

--- a/argocd/structure_application.go
+++ b/argocd/structure_application.go
@@ -259,6 +259,9 @@ func expandApplicationSourceHelm(in []interface{}) *application.ApplicationSourc
 			result.Parameters = append(result.Parameters, parameter)
 		}
 	}
+	if v, ok := a["skip_crds"]; ok {
+		result.SkipCrds = v.(bool)
+	}
 	return result
 }
 
@@ -672,6 +675,7 @@ func flattenApplicationSourceHelm(as []*application.ApplicationSourceHelm) (
 			result = append(result, map[string]interface{}{
 				"parameter":    parameters,
 				"release_name": a.ReleaseName,
+				"skip_crds":    a.SkipCrds,
 				"value_files":  a.ValueFiles,
 				"values":       a.Values,
 			})

--- a/docs/resources/application.md
+++ b/docs/resources/application.md
@@ -197,6 +197,7 @@ The `helm` block has the following attributes:
 * `value_files` - (Optional) list of Helm value files to use when generating a template.
 * `values` - (Optional) Helm values, typically defined as a block.
 * `release_name` - (Optional) the Helm release name. If omitted it will use the application name.
+* `skip_crds` - (Optional) Helm installs custom resource definitions in the crds folder by default if they are not existing. If needed, it is possible to skip the CRD installation step with this flag.
 * `parameter` - (Optional) parameter to the Helm template. Can be repeated multiple times. Structure is documented below.
 
 Each `helm/parameter` block has the following attributes:

--- a/scripts/testacc.sh
+++ b/scripts/testacc.sh
@@ -5,4 +5,4 @@ ARGOCD_SERVER=127.0.0.1:8080 \
 ARGOCD_AUTH_USERNAME=admin \
 ARGOCD_AUTH_PASSWORD=acceptancetesting \
 ARGOCD_CONTEXT=kind-argocd \
-TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -timeout 5m
+TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -timeout 8m


### PR DESCRIPTION
* added **skip_crds** to helm in `argocd_application` (Resolves #166)
```hcl diff
resource "argocd_application" "crds" {
  metadata {
	...
  }

  spec {
    source {
		repo_url        = "https://charts.bitnami.com/bitnami"
		chart           = "redis"
		target_revision = "15.3.0"
		helm {
		  release_name = "testing"
+		  skip_crds = true
		}
	}
    destination {
      server    = "https://kubernetes.default.svc"
      namespace = "default"
    }
  }
}
```
* added a StateUpgrader to add the default value (false)
* added a bunch of ResourceImporter tests 