### PR TITLE
feat: add resource argocd_repository_certificate 

### DIFF
--- a/argocd/features.go
+++ b/argocd/features.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Masterminds/semver"
 	"github.com/argoproj/argo-cd/v2/pkg/apiclient"
 	"github.com/argoproj/argo-cd/v2/pkg/apiclient/application"
+	"github.com/argoproj/argo-cd/v2/pkg/apiclient/certificate"
 	"github.com/argoproj/argo-cd/v2/pkg/apiclient/cluster"
 	"github.com/argoproj/argo-cd/v2/pkg/apiclient/project"
 	"github.com/argoproj/argo-cd/v2/pkg/apiclient/repocreds"
@@ -35,12 +36,14 @@ var (
 		featureTokenIDs:                    semver.MustParse("1.5.3"),
 		featureProjectScopedClusters:       semver.MustParse("2.2.0"),
 		featureClusterMetadata:             semver.MustParse("2.2.0"),
+		// TODO: should declare certificate 1.2+ ?
 	}
 )
 
 type ServerInterface struct {
 	ApiClient            *apiclient.Client
 	ApplicationClient    *application.ApplicationServiceClient
+	CertificateClient    *certificate.CertificateServiceClient
 	ClusterClient        *cluster.ClusterServiceClient
 	ProjectClient        *project.ProjectServiceClient
 	RepositoryClient     *repository.RepositoryServiceClient
@@ -77,6 +80,14 @@ func (p *ServerInterface) initClients() error {
 			return err
 		}
 		p.ClusterClient = &clusterClient
+	}
+
+	if p.CertificateClient == nil {
+		_, certClient, err := (*p.ApiClient).NewCertClient()
+		if err != nil {
+			return err
+		}
+		p.CertificateClient = &certClient
 	}
 
 	if p.ApplicationClient == nil {

--- a/argocd/features.go
+++ b/argocd/features.go
@@ -26,6 +26,7 @@ const (
 	featureTokenIDs
 	featureProjectScopedClusters
 	featureClusterMetadata
+	featureRepositoryCertificates
 )
 
 var (
@@ -36,7 +37,7 @@ var (
 		featureTokenIDs:                    semver.MustParse("1.5.3"),
 		featureProjectScopedClusters:       semver.MustParse("2.2.0"),
 		featureClusterMetadata:             semver.MustParse("2.2.0"),
-		// TODO: should declare certificate 1.2+ ?
+		featureRepositoryCertificates:      semver.MustParse("1.2.0"),
 	}
 )
 

--- a/argocd/provider.go
+++ b/argocd/provider.go
@@ -156,6 +156,7 @@ func Provider() *schema.Provider {
 
 		ResourcesMap: map[string]*schema.Resource{
 			"argocd_application":            resourceArgoCDApplication(),
+			"argocd_certificate":            resourceArgoCDRepositoryCertificates(),
 			"argocd_cluster":                resourceArgoCDCluster(),
 			"argocd_project":                resourceArgoCDProject(),
 			"argocd_project_token":          resourceArgoCDProjectToken(),

--- a/argocd/provider.go
+++ b/argocd/provider.go
@@ -156,7 +156,7 @@ func Provider() *schema.Provider {
 
 		ResourcesMap: map[string]*schema.Resource{
 			"argocd_application":            resourceArgoCDApplication(),
-			"argocd_certificate":            resourceArgoCDRepositoryCertificates(),
+			"argocd_repository_certificate": resourceArgoCDRepositoryCertificates(),
 			"argocd_cluster":                resourceArgoCDCluster(),
 			"argocd_project":                resourceArgoCDProject(),
 			"argocd_project_token":          resourceArgoCDProjectToken(),

--- a/argocd/resource_argocd_repository_certificates.go
+++ b/argocd/resource_argocd_repository_certificates.go
@@ -45,6 +45,29 @@ func resourceArgoCDRepositoryCertificatesCreate(ctx context.Context, d *schema.R
 			},
 		}
 	}
+
+	featureRepositoryCertificateSupported, err := server.isFeatureSupported(featureRepositoryCertificates)
+	if err != nil {
+		return []diag.Diagnostic{
+			{
+				Severity: diag.Error,
+				Summary:  "feature not supported",
+				Detail:   err.Error(),
+			},
+		}
+	}
+
+	if !featureRepositoryCertificateSupported {
+		return []diag.Diagnostic{
+			{
+				Severity: diag.Error,
+				Summary: fmt.Sprintf(
+					"repository certificate is only supported from ArgoCD %s onwards",
+					featureVersionConstraintsMap[featureRepositoryCertificates].String()),
+			},
+		}
+	}
+
 	c := *server.CertificateClient
 	certs := application.RepositoryCertificateList{
 		Items: []application.RepositoryCertificate{
@@ -134,6 +157,29 @@ func resourceArgoCDRepositoryCertificatesRead(ctx context.Context, d *schema.Res
 			},
 		}
 	}
+
+	featureRepositoryCertificateSupported, err := server.isFeatureSupported(featureRepositoryCertificates)
+	if err != nil {
+		return []diag.Diagnostic{
+			{
+				Severity: diag.Error,
+				Summary:  "feature not supported",
+				Detail:   err.Error(),
+			},
+		}
+	}
+
+	if !featureRepositoryCertificateSupported {
+		return []diag.Diagnostic{
+			{
+				Severity: diag.Error,
+				Summary: fmt.Sprintf(
+					"repository certificate is only supported from ArgoCD %s onwards",
+					featureVersionConstraintsMap[featureRepositoryCertificates].String()),
+			},
+		}
+	}
+
 	c := *server.CertificateClient
 	repoCertificate := application.RepositoryCertificate{}
 	err, certType, certSubType, serverName := fromId(d.Id())
@@ -215,6 +261,29 @@ func resourceArgoCDRepositoryCertificatesDelete(ctx context.Context, d *schema.R
 			},
 		}
 	}
+
+	featureRepositoryCertificateSupported, err := server.isFeatureSupported(featureRepositoryCertificates)
+	if err != nil {
+		return []diag.Diagnostic{
+			{
+				Severity: diag.Error,
+				Summary:  "feature not supported",
+				Detail:   err.Error(),
+			},
+		}
+	}
+
+	if !featureRepositoryCertificateSupported {
+		return []diag.Diagnostic{
+			{
+				Severity: diag.Error,
+				Summary: fmt.Sprintf(
+					"repository certificate is only supported from ArgoCD %s onwards",
+					featureVersionConstraintsMap[featureRepositoryCertificates].String()),
+			},
+		}
+	}
+
 	c := *server.CertificateClient
 	err, certType, certSubType, serverName := fromId(d.Id())
 	if err != nil {

--- a/argocd/resource_argocd_repository_certificates.go
+++ b/argocd/resource_argocd_repository_certificates.go
@@ -1,0 +1,222 @@
+package argocd
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/argoproj/argo-cd/v2/pkg/apiclient/certificate"
+	application "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceArgoCDRepositoryCertificates() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceArgoCDRepositoryCertificatesCreate,
+		ReadContext:   resourceArgoCDRepositoryCertificatesRead,
+		DeleteContext: resourceArgoCDRepositoryCertificatesDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Schema: certificatesSchema(),
+	}
+}
+
+func resourceArgoCDRepositoryCertificatesCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	repoCertificate, err := expandRepositoryCertificate(d)
+	if err != nil {
+		return []diag.Diagnostic{
+			{
+				Severity: diag.Error,
+				Summary:  fmt.Sprintf("certificate %s could not be created", d.Id()),
+				Detail:   err.Error(),
+			},
+		}
+	}
+
+	server := meta.(*ServerInterface)
+	if err := server.initClients(); err != nil {
+		return []diag.Diagnostic{
+			{
+				Severity: diag.Error,
+				Summary:  fmt.Sprintf("Failed to init clients"),
+				Detail:   err.Error(),
+			},
+		}
+	}
+	c := *server.CertificateClient
+	certs := application.RepositoryCertificateList{
+		Items: []application.RepositoryCertificate{
+			*repoCertificate,
+		},
+	}
+
+	tokenMutexConfiguration.Lock()
+	rc, err := c.CreateCertificate(
+		ctx,
+		&certificate.RepositoryCertificateCreateRequest{
+			Certificates: &certs,
+			Upsert:       true,
+		},
+	)
+	tokenMutexConfiguration.Unlock()
+
+	if err != nil {
+		return []diag.Diagnostic{
+			{
+				Severity: diag.Error,
+				Summary:  fmt.Sprintf("certificate for repository %s could not be created", repoCertificate.ServerName),
+				Detail:   err.Error(),
+			},
+		}
+	}
+	// If certificate already exists and didn't change, the response will be empty but since the call is success
+	// we assume everything went fine and get the id from the request
+	// if len(rc.Items) > 0 {
+	d.SetId(getId(&rc.Items[0]))
+	// } else {
+	// 	d.SetId(getId(repoCertificate))
+	// }
+	return resourceArgoCDRepositoryCertificatesRead(ctx, d, meta)
+}
+
+// Compute resource's id as : serverName/certType/certSubType
+func getId(rc *application.RepositoryCertificate) string {
+	return fmt.Sprintf("%s/%s/%s", rc.ServerName, rc.CertType, rc.CertSubType)
+}
+
+// Get serverName/certType/certSubType from resource's id
+func fromId(id string) (error, string, string, string) {
+	parts := strings.Split(id, "/")
+	if len(parts) < 3 || parts[0] == "" || parts[1] == "" || parts[2] == "" {
+		return fmt.Errorf("Unknown certificate %s in state", id), "", "", ""
+	}
+	return nil, parts[0], parts[1], parts[2]
+}
+
+func resourceArgoCDRepositoryCertificatesRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	server := meta.(*ServerInterface)
+	if err := server.initClients(); err != nil {
+		return []diag.Diagnostic{
+			{
+				Severity: diag.Error,
+				Summary:  fmt.Sprintf("Failed to init clients"),
+				Detail:   err.Error(),
+			},
+		}
+	}
+	c := *server.CertificateClient
+	repoCertificate := application.RepositoryCertificate{}
+	err, serverName, certType, certSubType := fromId(d.Id())
+	if err != nil {
+		return []diag.Diagnostic{
+			{
+				Severity: diag.Error,
+				Summary:  fmt.Sprintf("Failed to parse state"),
+				Detail:   err.Error(),
+			},
+		}
+	}
+
+	tokenMutexConfiguration.RLock()
+	rcl, err := c.ListCertificates(ctx, &certificate.RepositoryCertificateQuery{
+		HostNamePattern: serverName,
+		CertType:        certType,
+		CertSubType:     certSubType,
+	})
+	tokenMutexConfiguration.RUnlock()
+
+	if err != nil {
+		return []diag.Diagnostic{
+			{
+				Severity: diag.Error,
+				Summary:  fmt.Sprintf("certificates for host %s could not be listed", d.Id()),
+				Detail:   err.Error(),
+			},
+		}
+	}
+	if rcl == nil || len(rcl.Items) == 0 {
+		// Certificate have already been deleted in an out-of-band fashion
+		d.SetId("")
+		return nil
+	}
+	for i, _rc := range rcl.Items {
+		if getId(&_rc) == d.Id() {
+			repoCertificate = _rc
+			break
+		}
+		// Certificate have already been deleted in an out-of-band fashion
+		if i == len(rcl.Items)-1 {
+			d.SetId("")
+			return nil
+		}
+	}
+
+	err = flattenRepositoryCertificate(&repoCertificate, d)
+	if err != nil {
+		return []diag.Diagnostic{
+			{
+				Severity: diag.Error,
+				Summary:  fmt.Sprintf("certificate %s could not be flattened", d.Id()),
+				Detail:   err.Error(),
+			},
+		}
+	}
+	return nil
+}
+
+func resourceArgoCDRepositoryCertificatesDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	server := meta.(*ServerInterface)
+	if err := server.initClients(); err != nil {
+		return []diag.Diagnostic{
+			{
+				Severity: diag.Error,
+				Summary:  fmt.Sprintf("Failed to init clients"),
+				Detail:   err.Error(),
+			},
+		}
+	}
+	c := *server.CertificateClient
+	err, serverName, certType, certSubType := fromId(d.Id())
+	if err != nil {
+		return []diag.Diagnostic{
+			{
+				Severity: diag.Error,
+				Summary:  fmt.Sprintf("Failed to parse state"),
+				Detail:   err.Error(),
+			},
+		}
+	}
+
+	query := certificate.RepositoryCertificateQuery{
+		HostNamePattern: serverName,
+		CertType:        certType,
+		CertSubType:     certSubType,
+	}
+
+	tokenMutexConfiguration.Lock()
+	_, err = c.DeleteCertificate(
+		ctx,
+		&query,
+	)
+	tokenMutexConfiguration.Unlock()
+
+	if err != nil {
+		if strings.Contains(err.Error(), "NotFound") {
+			// Certificate have already been deleted in an out-of-band fashion
+			d.SetId("")
+			return nil
+		} else {
+			return []diag.Diagnostic{
+				{
+					Severity: diag.Error,
+					Summary:  fmt.Sprintf("certificate for repository %s could not be deleted", d.Id()),
+					Detail:   err.Error(),
+				},
+			}
+		}
+	}
+	d.SetId("")
+	return nil
+}

--- a/argocd/resource_argocd_repository_certificates.go
+++ b/argocd/resource_argocd_repository_certificates.go
@@ -16,10 +16,7 @@ func resourceArgoCDRepositoryCertificates() *schema.Resource {
 		CreateContext: resourceArgoCDRepositoryCertificatesCreate,
 		ReadContext:   resourceArgoCDRepositoryCertificatesRead,
 		DeleteContext: resourceArgoCDRepositoryCertificatesDelete,
-		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
-		},
-		Schema: certificatesSchema(),
+		Schema:        certificatesSchema(),
 	}
 }
 

--- a/argocd/resource_argocd_repository_certificates_test.go
+++ b/argocd/resource_argocd_repository_certificates_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestAccArgoCDRepositoryCertificatesSsh(t *testing.T) {
+func TestAccArgoCDRepositoryCertificatesSSH(t *testing.T) {
 	serverName := acctest.RandomWithPrefix("mywebsite")
 
 	resource.Test(t, resource.TestCase{
@@ -19,7 +19,7 @@ func TestAccArgoCDRepositoryCertificatesSsh(t *testing.T) {
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccArgoCDRepositoryCertificateSSH(
+				Config: testAccArgoCDRepositoryCertificatesSSH(
 					serverName,
 					"ecdsa-sha2-nistp256",
 					// gitlab's
@@ -33,7 +33,7 @@ func TestAccArgoCDRepositoryCertificatesSsh(t *testing.T) {
 			},
 			// same, no diff
 			{
-				Config: testAccArgoCDRepositoryCertificateSSH(
+				Config: testAccArgoCDRepositoryCertificatesSSH(
 					serverName,
 					"ecdsa-sha2-nistp256",
 					// gitlab's
@@ -44,7 +44,7 @@ func TestAccArgoCDRepositoryCertificatesSsh(t *testing.T) {
 			},
 			// change only the cert_data => same id => diff
 			{
-				Config: testAccArgoCDRepositoryCertificateSSH(
+				Config: testAccArgoCDRepositoryCertificatesSSH(
 					serverName,
 					"ecdsa-sha2-nistp256",
 					// github's
@@ -55,7 +55,7 @@ func TestAccArgoCDRepositoryCertificatesSsh(t *testing.T) {
 			},
 			// change cert_subtype & cert_data => changes id => diff
 			{
-				Config: testAccArgoCDRepositoryCertificateSSH(
+				Config: testAccArgoCDRepositoryCertificatesSSH(
 					serverName,
 					"ssh-rsa",
 					// github's
@@ -105,7 +105,7 @@ func TestAccArgoCDRepositoryCertificatesHttps(t *testing.T) {
 	})
 }
 
-func TestAccArgoCDRepositoryCertificatesHttpsCrash(t *testing.T) {
+func TestAccArgoCDRepositoryCertificatesHttps_Crash(t *testing.T) {
 	serverName := acctest.RandomWithPrefix("github")
 
 	resource.Test(t, resource.TestCase{
@@ -140,7 +140,7 @@ func TestAccArgoCDRepositoryCertificatesHttpsCrash(t *testing.T) {
 	})
 }
 
-func TestAccArgoCDRepositoryCertificatesInvalid(t *testing.T) {
+func TestAccArgoCDRepositoryCertificatesSSH_Invalid(t *testing.T) {
 	certSubType := acctest.RandomWithPrefix("cert")
 
 	resource.Test(t, resource.TestCase{
@@ -148,7 +148,7 @@ func TestAccArgoCDRepositoryCertificatesInvalid(t *testing.T) {
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccArgoCDRepositoryCertificateSSH(
+				Config: testAccArgoCDRepositoryCertificatesSSH(
 					"",
 					certSubType,
 					"",
@@ -156,7 +156,7 @@ func TestAccArgoCDRepositoryCertificatesInvalid(t *testing.T) {
 				ExpectError: regexp.MustCompile("Invalid hostname in request"),
 			},
 			{
-				Config: testAccArgoCDRepositoryCertificateSSH(
+				Config: testAccArgoCDRepositoryCertificatesSSH(
 					"dummy_server",
 					certSubType,
 					"",
@@ -167,20 +167,20 @@ func TestAccArgoCDRepositoryCertificatesInvalid(t *testing.T) {
 	})
 }
 
-func TestAccArgoCDRepositoryCertificatesEmpty(t *testing.T) {
+func TestAccArgoCDRepositoryCertificates_Empty(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccArgoCDRepositoryCertificateEmpty(),
+				Config:      testAccArgoCDRepositoryCertificates_Empty(),
 				ExpectError: regexp.MustCompile("one of `https,ssh` must be specified"),
 			},
 		},
 	})
 }
 
-func TestAccArgoCDRepositoryCertificatesSsh_Allow_Random_Subtype(t *testing.T) {
+func TestAccArgoCDRepositoryCertificatesSSH_Allow_Random_Subtype(t *testing.T) {
 	certSubType := acctest.RandomWithPrefix("cert")
 
 	resource.Test(t, resource.TestCase{
@@ -188,7 +188,7 @@ func TestAccArgoCDRepositoryCertificatesSsh_Allow_Random_Subtype(t *testing.T) {
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccArgoCDRepositoryCertificateSSH(
+				Config: testAccArgoCDRepositoryCertificatesSSH(
 					"dummy_server",
 					certSubType,
 					"AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFSMqzJeV9rUzU4kWitGjeR4PWSa29SPqJ1fVkhtj3Hw9xjLVXVYrU9QlYWrOLXBpQ6KWjbjTDTdDkoohFzgbEY=",
@@ -198,7 +198,7 @@ func TestAccArgoCDRepositoryCertificatesSsh_Allow_Random_Subtype(t *testing.T) {
 	})
 }
 
-func TestAccArgoCDRepositoryCertificatesWithApplication(t *testing.T) {
+func TestAccArgoCDRepositoryCertificatesSSH_WithApplication(t *testing.T) {
 	appName := acctest.RandomWithPrefix("testacc")
 
 	err, subtypesKeys := getSshKeysForHost("private-git-repository")
@@ -225,14 +225,68 @@ func TestAccArgoCDRepositoryCertificatesWithApplication(t *testing.T) {
 	})
 }
 
-func testAccArgoCDRepositoryCertificateEmpty() string {
+func TestAccArgoCDRepositoryCertificatesSSH_CannotUpdateExisting(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccArgoCDRepositoryCertificatesSSH(
+					"github.com",
+					"ssh-rsa",
+					// github's
+					"AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==",
+				),
+				ExpectError: regexp.MustCompile("already exist and upsert was not specified"),
+			},
+		},
+	})
+}
+
+func TestAccArgoCDRepositoryCertificatesSSH_CannotUpdateExisting_MultipleAtOnce(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccArgoCDRepositoryCertificateSSH_Duplicated(
+					"github.com",
+					"ssh-rsaaa",
+					// github's
+					"AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==",
+				),
+				ExpectError: regexp.MustCompile("already exist and upsert was not specified"),
+			},
+		},
+	})
+}
+
+func TestAccArgoCDRepositoryCertificatesHttps_CannotUpdateExisting_MultipleAtOnce(t *testing.T) {
+	host := "github.com"
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccArgoCDRepositoryCertificateHttps_Duplicated(
+					host,
+					// github's
+					"-----BEGIN CERTIFICATE-----\nMIIFajCCBPCgAwIBAgIQBRiaVOvox+kD4KsNklVF3jAKBggqhkjOPQQDAzBWMQsw\nCQYDVQQGEwJVUzEVMBMGA1UEChMMRGlnaUNlcnQgSW5jMTAwLgYDVQQDEydEaWdp\nQ2VydCBUTFMgSHlicmlkIEVDQyBTSEEzODQgMjAyMCBDQTEwHhcNMjIwMzE1MDAw\nMDAwWhcNMjMwMzE1MjM1OTU5WjBmMQswCQYDVQQGEwJVUzETMBEGA1UECBMKQ2Fs\naWZvcm5pYTEWMBQGA1UEBxMNU2FuIEZyYW5jaXNjbzEVMBMGA1UEChMMR2l0SHVi\nLCBJbmMuMRMwEQYDVQQDEwpnaXRodWIuY29tMFkwEwYHKoZIzj0CAQYIKoZIzj0D\nAQcDQgAESrCTcYUh7GI/y3TARsjnANwnSjJLitVRgwgRI1JlxZ1kdZQQn5ltP3v7\nKTtYuDdUeEu3PRx3fpDdu2cjMlyA0aOCA44wggOKMB8GA1UdIwQYMBaAFAq8CCkX\njKU5bXoOzjPHLrPt+8N6MB0GA1UdDgQWBBR4qnLGcWloFLVZsZ6LbitAh0I7HjAl\nBgNVHREEHjAcggpnaXRodWIuY29tgg53d3cuZ2l0aHViLmNvbTAOBgNVHQ8BAf8E\nBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMIGbBgNVHR8EgZMw\ngZAwRqBEoEKGQGh0dHA6Ly9jcmwzLmRpZ2ljZXJ0LmNvbS9EaWdpQ2VydFRMU0h5\nYnJpZEVDQ1NIQTM4NDIwMjBDQTEtMS5jcmwwRqBEoEKGQGh0dHA6Ly9jcmw0LmRp\nZ2ljZXJ0LmNvbS9EaWdpQ2VydFRMU0h5YnJpZEVDQ1NIQTM4NDIwMjBDQTEtMS5j\ncmwwPgYDVR0gBDcwNTAzBgZngQwBAgIwKTAnBggrBgEFBQcCARYbaHR0cDovL3d3\ndy5kaWdpY2VydC5jb20vQ1BTMIGFBggrBgEFBQcBAQR5MHcwJAYIKwYBBQUHMAGG\nGGh0dHA6Ly9vY3NwLmRpZ2ljZXJ0LmNvbTBPBggrBgEFBQcwAoZDaHR0cDovL2Nh\nY2VydHMuZGlnaWNlcnQuY29tL0RpZ2lDZXJ0VExTSHlicmlkRUNDU0hBMzg0MjAy\nMENBMS0xLmNydDAJBgNVHRMEAjAAMIIBfwYKKwYBBAHWeQIEAgSCAW8EggFrAWkA\ndgCt9776fP8QyIudPZwePhhqtGcpXc+xDCTKhYY069yCigAAAX+Oi8SRAAAEAwBH\nMEUCIAR9cNnvYkZeKs9JElpeXwztYB2yLhtc8bB0rY2ke98nAiEAjiML8HZ7aeVE\nP/DkUltwIS4c73VVrG9JguoRrII7gWMAdwA1zxkbv7FsV78PrUxtQsu7ticgJlHq\nP+Eq76gDwzvWTAAAAX+Oi8R7AAAEAwBIMEYCIQDNckqvBhup7GpANMf0WPueytL8\nu/PBaIAObzNZeNMpOgIhAMjfEtE6AJ2fTjYCFh/BNVKk1mkTwBTavJlGmWomQyaB\nAHYAs3N3B+GEUPhjhtYFqdwRCUp5LbFnDAuH3PADDnk2pZoAAAF/jovErAAABAMA\nRzBFAiEA9Uj5Ed/XjQpj/MxQRQjzG0UFQLmgWlc73nnt3CJ7vskCICqHfBKlDz7R\nEHdV5Vk8bLMBW1Q6S7Ga2SbFuoVXs6zFMAoGCCqGSM49BAMDA2gAMGUCMCiVhqft\n7L/stBmv1XqSRNfE/jG/AqKIbmjGTocNbuQ7kt1Cs7kRg+b3b3C9Ipu5FQIxAM7c\ntGKrYDGt0pH8iF6rzbp9Q4HQXMZXkNxg+brjWxnaOVGTDNwNH7048+s/hT9bUQ==\n-----END CERTIFICATE-----",
+				),
+				ExpectError: regexp.MustCompile(fmt.Sprintf("https certificate for '%s' already exist.", host)),
+			},
+		},
+	})
+}
+
+func testAccArgoCDRepositoryCertificates_Empty() string {
 	return `
 resource "argocd_certificate" "simple" {
 }
 `
 }
 
-func testAccArgoCDRepositoryCertificateSSH(serverName, cert_subtype, cert_data string) string {
+func testAccArgoCDRepositoryCertificatesSSH(serverName, cert_subtype, cert_data string) string {
 	return fmt.Sprintf(`
 resource "argocd_certificate" "simple" {
   ssh {
@@ -246,6 +300,30 @@ EOT
 `, serverName, cert_subtype, cert_data)
 }
 
+func testAccArgoCDRepositoryCertificateSSH_Duplicated(serverName, cert_subtype, cert_data string) string {
+	return fmt.Sprintf(`
+resource "argocd_certificate" "simple" {
+  ssh {
+	server_name  = "%s"
+	cert_subtype = "%s"
+	cert_data    = <<EOT
+%s
+EOT
+  }
+}
+
+resource "argocd_certificate" "simple2" {
+	ssh {
+	  server_name  = "%s"
+	  cert_subtype = "%s"
+	  cert_data    = <<EOT
+  %s
+  EOT
+	}
+  }
+`, serverName, cert_subtype, cert_data, serverName, cert_subtype, cert_data)
+}
+
 func testAccArgoCDRepositoryCertificateHttps(serverName, cert_data string) string {
 	return fmt.Sprintf(`
 resource "argocd_certificate" "simple" {
@@ -257,6 +335,28 @@ EOT
   }
 }
 `, serverName, cert_data)
+}
+
+func testAccArgoCDRepositoryCertificateHttps_Duplicated(serverName, cert_data string) string {
+	return fmt.Sprintf(`
+resource "argocd_certificate" "simple" {
+  https {
+    server_name  = "%s"
+    cert_data    = <<EOT
+%s
+EOT
+  }
+}
+
+resource "argocd_certificate" "simple2" {
+  https {
+    server_name  = "%s"
+    cert_data    = <<EOT
+%s
+EOT
+  }
+}
+`, serverName, cert_data, serverName, cert_data)
 }
 
 func testAccArgoCDRepositoryCertificateCredentialsApplicationWithSSH(random string, subtypesKeys []string) string {

--- a/argocd/resource_argocd_repository_certificates_test.go
+++ b/argocd/resource_argocd_repository_certificates_test.go
@@ -66,13 +66,6 @@ func TestAccArgoCDRepositoryCertificatesSsh(t *testing.T) {
 					resource.TestCheckResourceAttr("argocd_certificate.simple", "ssh.0.cert_subtype", "ssh-rsa"),
 				),
 			},
-			{
-				ResourceName:            "argocd_certificate.simple",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"ssh.0.cert_data"},
-				Destroy:                 true,
-			},
 		},
 	})
 }
@@ -108,13 +101,6 @@ func TestAccArgoCDRepositoryCertificatesHttps(t *testing.T) {
 					resource.TestCheckResourceAttrSet("argocd_certificate.simple", "https.0.cert_info"),
 				),
 			},
-			{
-				ResourceName:            "argocd_certificate.simple",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"https.0.cert_data"},
-				Destroy:                 true,
-			},
 		},
 	})
 }
@@ -149,13 +135,6 @@ func TestAccArgoCDRepositoryCertificatesHttpsCrash(t *testing.T) {
 					resource.TestCheckResourceAttr("argocd_certificate.simple", "https.0.cert_subtype", "rsa"),
 					resource.TestCheckResourceAttrSet("argocd_certificate.simple", "https.0.cert_info"),
 				),
-			},
-			{
-				ResourceName:            "argocd_certificate.simple",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"https.0.cert_data"},
-				Destroy:                 true,
 			},
 		},
 	})

--- a/argocd/resource_argocd_repository_certificates_test.go
+++ b/argocd/resource_argocd_repository_certificates_test.go
@@ -26,9 +26,9 @@ func TestAccArgoCDRepositoryCertificatesSSH(t *testing.T) {
 					"AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFSMqzJeV9rUzU4kWitGjeR4PWSa29SPqJ1fVkhtj3Hw9xjLVXVYrU9QlYWrOLXBpQ6KWjbjTDTdDkoohFzgbEY=",
 				),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("argocd_certificate.simple", "ssh.0.server_name", serverName),
-					resource.TestCheckResourceAttr("argocd_certificate.simple", "ssh.0.cert_subtype", "ecdsa-sha2-nistp256"),
-					resource.TestCheckResourceAttrSet("argocd_certificate.simple", "ssh.0.cert_info"),
+					resource.TestCheckResourceAttr("argocd_repository_certificate.simple", "ssh.0.server_name", serverName),
+					resource.TestCheckResourceAttr("argocd_repository_certificate.simple", "ssh.0.cert_subtype", "ecdsa-sha2-nistp256"),
+					resource.TestCheckResourceAttrSet("argocd_repository_certificate.simple", "ssh.0.cert_info"),
 				),
 			},
 			// same, no diff
@@ -62,8 +62,8 @@ func TestAccArgoCDRepositoryCertificatesSSH(t *testing.T) {
 					"AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==",
 				),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("argocd_certificate.simple", "ssh.0.server_name", serverName),
-					resource.TestCheckResourceAttr("argocd_certificate.simple", "ssh.0.cert_subtype", "ssh-rsa"),
+					resource.TestCheckResourceAttr("argocd_repository_certificate.simple", "ssh.0.server_name", serverName),
+					resource.TestCheckResourceAttr("argocd_repository_certificate.simple", "ssh.0.cert_subtype", "ssh-rsa"),
 				),
 			},
 		},
@@ -84,9 +84,9 @@ func TestAccArgoCDRepositoryCertificatesHttps(t *testing.T) {
 					"-----BEGIN CERTIFICATE-----\nMIIFajCCBPCgAwIBAgIQBRiaVOvox+kD4KsNklVF3jAKBggqhkjOPQQDAzBWMQsw\nCQYDVQQGEwJVUzEVMBMGA1UEChMMRGlnaUNlcnQgSW5jMTAwLgYDVQQDEydEaWdp\nQ2VydCBUTFMgSHlicmlkIEVDQyBTSEEzODQgMjAyMCBDQTEwHhcNMjIwMzE1MDAw\nMDAwWhcNMjMwMzE1MjM1OTU5WjBmMQswCQYDVQQGEwJVUzETMBEGA1UECBMKQ2Fs\naWZvcm5pYTEWMBQGA1UEBxMNU2FuIEZyYW5jaXNjbzEVMBMGA1UEChMMR2l0SHVi\nLCBJbmMuMRMwEQYDVQQDEwpnaXRodWIuY29tMFkwEwYHKoZIzj0CAQYIKoZIzj0D\nAQcDQgAESrCTcYUh7GI/y3TARsjnANwnSjJLitVRgwgRI1JlxZ1kdZQQn5ltP3v7\nKTtYuDdUeEu3PRx3fpDdu2cjMlyA0aOCA44wggOKMB8GA1UdIwQYMBaAFAq8CCkX\njKU5bXoOzjPHLrPt+8N6MB0GA1UdDgQWBBR4qnLGcWloFLVZsZ6LbitAh0I7HjAl\nBgNVHREEHjAcggpnaXRodWIuY29tgg53d3cuZ2l0aHViLmNvbTAOBgNVHQ8BAf8E\nBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMIGbBgNVHR8EgZMw\ngZAwRqBEoEKGQGh0dHA6Ly9jcmwzLmRpZ2ljZXJ0LmNvbS9EaWdpQ2VydFRMU0h5\nYnJpZEVDQ1NIQTM4NDIwMjBDQTEtMS5jcmwwRqBEoEKGQGh0dHA6Ly9jcmw0LmRp\nZ2ljZXJ0LmNvbS9EaWdpQ2VydFRMU0h5YnJpZEVDQ1NIQTM4NDIwMjBDQTEtMS5j\ncmwwPgYDVR0gBDcwNTAzBgZngQwBAgIwKTAnBggrBgEFBQcCARYbaHR0cDovL3d3\ndy5kaWdpY2VydC5jb20vQ1BTMIGFBggrBgEFBQcBAQR5MHcwJAYIKwYBBQUHMAGG\nGGh0dHA6Ly9vY3NwLmRpZ2ljZXJ0LmNvbTBPBggrBgEFBQcwAoZDaHR0cDovL2Nh\nY2VydHMuZGlnaWNlcnQuY29tL0RpZ2lDZXJ0VExTSHlicmlkRUNDU0hBMzg0MjAy\nMENBMS0xLmNydDAJBgNVHRMEAjAAMIIBfwYKKwYBBAHWeQIEAgSCAW8EggFrAWkA\ndgCt9776fP8QyIudPZwePhhqtGcpXc+xDCTKhYY069yCigAAAX+Oi8SRAAAEAwBH\nMEUCIAR9cNnvYkZeKs9JElpeXwztYB2yLhtc8bB0rY2ke98nAiEAjiML8HZ7aeVE\nP/DkUltwIS4c73VVrG9JguoRrII7gWMAdwA1zxkbv7FsV78PrUxtQsu7ticgJlHq\nP+Eq76gDwzvWTAAAAX+Oi8R7AAAEAwBIMEYCIQDNckqvBhup7GpANMf0WPueytL8\nu/PBaIAObzNZeNMpOgIhAMjfEtE6AJ2fTjYCFh/BNVKk1mkTwBTavJlGmWomQyaB\nAHYAs3N3B+GEUPhjhtYFqdwRCUp5LbFnDAuH3PADDnk2pZoAAAF/jovErAAABAMA\nRzBFAiEA9Uj5Ed/XjQpj/MxQRQjzG0UFQLmgWlc73nnt3CJ7vskCICqHfBKlDz7R\nEHdV5Vk8bLMBW1Q6S7Ga2SbFuoVXs6zFMAoGCCqGSM49BAMDA2gAMGUCMCiVhqft\n7L/stBmv1XqSRNfE/jG/AqKIbmjGTocNbuQ7kt1Cs7kRg+b3b3C9Ipu5FQIxAM7c\ntGKrYDGt0pH8iF6rzbp9Q4HQXMZXkNxg+brjWxnaOVGTDNwNH7048+s/hT9bUQ==\n-----END CERTIFICATE-----",
 				),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("argocd_certificate.simple", "https.0.server_name", serverName),
-					resource.TestCheckResourceAttr("argocd_certificate.simple", "https.0.cert_subtype", "ecdsa"),
-					resource.TestCheckResourceAttrSet("argocd_certificate.simple", "https.0.cert_info"),
+					resource.TestCheckResourceAttr("argocd_repository_certificate.simple", "https.0.server_name", serverName),
+					resource.TestCheckResourceAttr("argocd_repository_certificate.simple", "https.0.cert_subtype", "ecdsa"),
+					resource.TestCheckResourceAttrSet("argocd_repository_certificate.simple", "https.0.cert_info"),
 				),
 			},
 			{
@@ -96,9 +96,9 @@ func TestAccArgoCDRepositoryCertificatesHttps(t *testing.T) {
 					"-----BEGIN CERTIFICATE-----\nMIIGBzCCBO+gAwIBAgIQXCLSMilzZJR9TSABzbgKzzANBgkqhkiG9w0BAQsFADCB\njzELMAkGA1UEBhMCR0IxGzAZBgNVBAgTEkdyZWF0ZXIgTWFuY2hlc3RlcjEQMA4G\nA1UEBxMHU2FsZm9yZDEYMBYGA1UEChMPU2VjdGlnbyBMaW1pdGVkMTcwNQYDVQQD\nEy5TZWN0aWdvIFJTQSBEb21haW4gVmFsaWRhdGlvbiBTZWN1cmUgU2VydmVyIENB\nMB4XDTIxMDQxMjAwMDAwMFoXDTIyMDUxMTIzNTk1OVowFTETMBEGA1UEAxMKZ2l0\nbGFiLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBANXnhcvOl289\n8oMglaax6bDz988oNMpXZCH6sI7Fzx9G/isEPObN6cyP+fjFa0dvwRmOHnepk2eo\nbzcECdgdBLCa7E29p7lLF0NFFTuIb52ew58fK/209XJ3amvjJ/m5rPP00uHrT+9v\nky2jkQUQszuC9R4vK+tfs2S5z9w6qh3hwIJecChzWKce8hRZdiO9S7ix/6ZNiAgw\nY2h8AiG0VruPOJ6PbNXOFUTsajK0EP8AzJfNDIjvWHjUOawR352m4eKxXvXm9knd\nB/w1gY90jmAQ9JIiyOm+QlmHwO+qQUpWYOxt5Xnb0Pp/RRHEtxDgjygQWajAwsxG\nobx6sCf6+qcCAwEAAaOCAtYwggLSMB8GA1UdIwQYMBaAFI2MXsRUrYrhd+mb+ZsF\n4bgBjWHhMB0GA1UdDgQWBBTFjbuGoOUrgk9Dhr35DblkBZCj1jAOBgNVHQ8BAf8E\nBAMCBaAwDAYDVR0TAQH/BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUH\nAwIwSQYDVR0gBEIwQDA0BgsrBgEEAbIxAQICBzAlMCMGCCsGAQUFBwIBFhdodHRw\nczovL3NlY3RpZ28uY29tL0NQUzAIBgZngQwBAgEwgYQGCCsGAQUFBwEBBHgwdjBP\nBggrBgEFBQcwAoZDaHR0cDovL2NydC5zZWN0aWdvLmNvbS9TZWN0aWdvUlNBRG9t\nYWluVmFsaWRhdGlvblNlY3VyZVNlcnZlckNBLmNydDAjBggrBgEFBQcwAYYXaHR0\ncDovL29jc3Auc2VjdGlnby5jb20wggEEBgorBgEEAdZ5AgQCBIH1BIHyAPAAdgBG\npVXrdfqRIDC1oolp9PN9ESxBdL79SbiFq/L8cP5tRwAAAXjDcW8TAAAEAwBHMEUC\nIQCxf+r8/dbHJDrh0YTAKSwdR8VUxAT6kHN5/HLuOvSsKgIgY2jAAf/tr59/f0JX\nKvHaN4qIv54gtj+KsNo7N0d4xcEAdgDfpV6raIJPH2yt7rhfTj5a6s2iEqRqXo47\nEsAgRFwqcwAAAXjDcW7VAAAEAwBHMEUCID0jtWvtpO1yypP7i7SeZZb3dQ6QdLlD\nlXpvWhjqrQfdAiEA0gp8tTUwOt2XN01OVTUrDgb4wV5VbFtx1SSYNFREQxwweQYD\nVR0RBHIwcIIKZ2l0bGFiLmNvbYIPYXV0aC5naXRsYWIuY29tghRjdXN0b21lcnMu\nZ2l0bGFiLmNvbYIaZW1haWwuY3VzdG9tZXJzLmdpdGxhYi5jb22CD2dwcmQuZ2l0\nbGFiLmNvbYIOd3d3LmdpdGxhYi5jb20wDQYJKoZIhvcNAQELBQADggEBAD7lgx6z\ncZI+uLtr7fYWOZDtPChNy7YjAXVtDbrQ61D1lESUIZwyDF9/xCDMqMSe+It2+j+t\nT0PHkbz6zbJdUMQhQxW0RLMZUthPg66YLqRJuvBU7VdWHxhqjfFb9UZvxOzTGgmN\nMuzmdThtlhRacNCTxGO/AJfcAt13RbKyR30UtqHb883qAH6isQvYFsQmijXcJXiT\ntRbcJ1Dm/dI+57BCTYLp2WfBdg0Axla5QsApQ+ER5GZoY1m6H3+OWpX77IdCgXF+\nHMtKCn08QLVBjhLr3IkeKgrYJTR1IDmzRwGUuUVvn1iO9+W10GV02SMngdN4nFp3\nwoE3CsYogf1SfQM=\n-----END CERTIFICATE-----",
 				),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("argocd_certificate.simple", "https.0.server_name", serverName),
-					resource.TestCheckResourceAttr("argocd_certificate.simple", "https.0.cert_subtype", "rsa"),
-					resource.TestCheckResourceAttrSet("argocd_certificate.simple", "https.0.cert_info"),
+					resource.TestCheckResourceAttr("argocd_repository_certificate.simple", "https.0.server_name", serverName),
+					resource.TestCheckResourceAttr("argocd_repository_certificate.simple", "https.0.cert_subtype", "rsa"),
+					resource.TestCheckResourceAttrSet("argocd_repository_certificate.simple", "https.0.cert_info"),
 				),
 			},
 		},
@@ -119,9 +119,9 @@ func TestAccArgoCDRepositoryCertificatesHttps_Crash(t *testing.T) {
 					"-----BEGIN CERTIFICATE-----\nMIIFajCCBPCgAwIBAgIQBRiaVOvox+kD4KsNklVF3jAKBggqhkjOPQQDAzBWMQsw\nCQYDVQQGEwJVUzEVMBMGA1UEChMMRGlnaUNlcnQgSW5jMTAwLgYDVQQDEydEaWdp\nQ2VydCBUTFMgSHlicmlkIEVDQyBTSEEzODQgMjAyMCBDQTEwHhcNMjIwMzE1MDAw\nMDAwWhcNMjMwMzE1MjM1OTU5WjBmMQswCQYDVQQGEwJVUzETMBEGA1UECBMKQ2Fs\naWZvcm5pYTEWMBQGA1UEBxMNU2FuIEZyYW5jaXNjbzEVMBMGA1UEChMMR2l0SHVi\nLCBJbmMuMRMwEQYDVQQDEwpnaXRodWIuY29tMFkwEwYHKoZIzj0CAQYIKoZIzj0D\nAQcDQgAESrCTcYUh7GI/y3TARsjnANwnSjJLitVRgwgRI1JlxZ1kdZQQn5ltP3v7\nKTtYuDdUeEu3PRx3fpDdu2cjMlyA0aOCA44wggOKMB8GA1UdIwQYMBaAFAq8CCkX\njKU5bXoOzjPHLrPt+8N6MB0GA1UdDgQWBBR4qnLGcWloFLVZsZ6LbitAh0I7HjAl\nBgNVHREEHjAcggpnaXRodWIuY29tgg53d3cuZ2l0aHViLmNvbTAOBgNVHQ8BAf8E\nBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMIGbBgNVHR8EgZMw\ngZAwRqBEoEKGQGh0dHA6Ly9jcmwzLmRpZ2ljZXJ0LmNvbS9EaWdpQ2VydFRMU0h5\nYnJpZEVDQ1NIQTM4NDIwMjBDQTEtMS5jcmwwRqBEoEKGQGh0dHA6Ly9jcmw0LmRp\nZ2ljZXJ0LmNvbS9EaWdpQ2VydFRMU0h5YnJpZEVDQ1NIQTM4NDIwMjBDQTEtMS5j\ncmwwPgYDVR0gBDcwNTAzBgZngQwBAgIwKTAnBggrBgEFBQcCARYbaHR0cDovL3d3\ndy5kaWdpY2VydC5jb20vQ1BTMIGFBggrBgEFBQcBAQR5MHcwJAYIKwYBBQUHMAGG\nGGh0dHA6Ly9vY3NwLmRpZ2ljZXJ0LmNvbTBPBggrBgEFBQcwAoZDaHR0cDovL2Nh\nY2VydHMuZGlnaWNlcnQuY29tL0RpZ2lDZXJ0VExTSHlicmlkRUNDU0hBMzg0MjAy\nMENBMS0xLmNydDAJBgNVHRMEAjAAMIIBfwYKKwYBBAHWeQIEAgSCAW8EggFrAWkA\ndgCt9776fP8QyIudPZwePhhqtGcpXc+xDCTKhYY069yCigAAAX+Oi8SRAAAEAwBH\nMEUCIAR9cNnvYkZeKs9JElpeXwztYB2yLhtc8bB0rY2ke98nAiEAjiML8HZ7aeVE\nP/DkUltwIS4c73VVrG9JguoRrII7gWMAdwA1zxkbv7FsV78PrUxtQsu7ticgJlHq\nP+Eq76gDwzvWTAAAAX+Oi8R7AAAEAwBIMEYCIQDNckqvBhup7GpANMf0WPueytL8\nu/PBaIAObzNZeNMpOgIhAMjfEtE6AJ2fTjYCFh/BNVKk1mkTwBTavJlGmWomQyaB\nAHYAs3N3B+GEUPhjhtYFqdwRCUp5LbFnDAuH3PADDnk2pZoAAAF/jovErAAABAMA\nRzBFAiEA9Uj5Ed/XjQpj/MxQRQjzG0UFQLmgWlc73nnt3CJ7vskCICqHfBKlDz7R\nEHdV5Vk8bLMBW1Q6S7Ga2SbFuoVXs6zFMAoGCCqGSM49BAMDA2gAMGUCMCiVhqft\n7L/stBmv1XqSRNfE/jG/AqKIbmjGTocNbuQ7kt1Cs7kRg+b3b3C9Ipu5FQIxAM7c\ntGKrYDGt0pH8iF6rzbp9Q4HQXMZXkNxg+brjWxnaOVGTDNwNH7048+s/hT9bUQ==\n-----END CERTIFICATE-----",
 				),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("argocd_certificate.simple", "https.0.server_name", serverName),
-					resource.TestCheckResourceAttr("argocd_certificate.simple", "https.0.cert_subtype", "ecdsa"),
-					resource.TestCheckResourceAttrSet("argocd_certificate.simple", "https.0.cert_info"),
+					resource.TestCheckResourceAttr("argocd_repository_certificate.simple", "https.0.server_name", serverName),
+					resource.TestCheckResourceAttr("argocd_repository_certificate.simple", "https.0.cert_subtype", "ecdsa"),
+					resource.TestCheckResourceAttrSet("argocd_repository_certificate.simple", "https.0.cert_info"),
 				),
 			},
 			{
@@ -131,9 +131,9 @@ func TestAccArgoCDRepositoryCertificatesHttps_Crash(t *testing.T) {
 					"-----BEGIN CERTIFICATE-----\nMIIGBzCCBO+gAwIBAgIQXCLSMilzZJR9TSABzbgKzzANBgkqhkiG9w0BAQsFADCB\njzELMAkGA1UEBhMCR0IxGzAZBgNVBAgTEkdyZWF0ZXIgTWFuY2hlc3RlcjEQMA4G\nA1UEBxMHU2FsZm9yZDEYMBYGA1UEChMPU2VjdGlnbyBMaW1pdGVkMTcwNQYDVQQD\nEy5TZWN0aWdvIFJTQSBEb21haW4gVmFsaWRhdGlvbiBTZWN1cmUgU2VydmVyIENB\nMB4XDTIxMDQxMjAwMDAwMFoXDTIyMDUxMTIzNTk1OVowFTETMBEGA1UEAxMKZ2l0\nbGFiLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBANXnhcvOl289\n8oMglaax6bDz988oNMpXZCH6sI7Fzx9G/isEPObN6cyP+fjFa0dvwRmOHnepk2eo\nbzcECdgdBLCa7E29p7lLF0NFFTuIb52ew58fK/209XJ3amvjJ/m5rPP00uHrT+9v\nky2jkQUQszuC9R4vK+tfs2S5z9w6qh3hwIJecChzWKce8hRZdiO9S7ix/6ZNiAgw\nY2h8AiG0VruPOJ6PbNXOFUTsajK0EP8AzJfNDIjvWHjUOawR352m4eKxXvXm9knd\nB/w1gY90jmAQ9JIiyOm+QlmHwO+qQUpWYOxt5Xnb0Pp/RRHEtxDgjygQWajAwsxG\nobx6sCf6+qcCAwEAAaOCAtYwggLSMB8GA1UdIwQYMBaAFI2MXsRUrYrhd+mb+ZsF\n4bgBjWHhMB0GA1UdDgQWBBTFjbuGoOUrgk9Dhr35DblkBZCj1jAOBgNVHQ8BAf8E\nBAMCBaAwDAYDVR0TAQH/BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUH\nAwIwSQYDVR0gBEIwQDA0BgsrBgEEAbIxAQICBzAlMCMGCCsGAQUFBwIBFhdodHRw\nczovL3NlY3RpZ28uY29tL0NQUzAIBgZngQwBAgEwgYQGCCsGAQUFBwEBBHgwdjBP\nBggrBgEFBQcwAoZDaHR0cDovL2NydC5zZWN0aWdvLmNvbS9TZWN0aWdvUlNBRG9t\nYWluVmFsaWRhdGlvblNlY3VyZVNlcnZlckNBLmNydDAjBggrBgEFBQcwAYYXaHR0\ncDovL29jc3Auc2VjdGlnby5jb20wggEEBgorBgEEAdZ5AgQCBIH1BIHyAPAAdgBG\npVXrdfqRIDC1oolp9PN9ESxBdL79SbiFq/L8cP5tRwAAAXjDcW8TAAAEAwBHMEUC\nIQCxf+r8/dbHJDrh0YTAKSwdR8VUxAT6kHN5/HLuOvSsKgIgY2jAAf/tr59/f0JX\nKvHaN4qIv54gtj+KsNo7N0d4xcEAdgDfpV6raIJPH2yt7rhfTj5a6s2iEqRqXo47\nEsAgRFwqcwAAAXjDcW7VAAAEAwBHMEUCID0jtWvtpO1yypP7i7SeZZb3dQ6QdLlD\nlXpvWhjqrQfdAiEA0gp8tTUwOt2XN01OVTUrDgb4wV5VbFtx1SSYNFREQxwweQYD\nVR0RBHIwcIIKZ2l0bGFiLmNvbYIPYXV0aC5naXRsYWIuY29tghRjdXN0b21lcnMu\nZ2l0bGFiLmNvbYIaZW1haWwuY3VzdG9tZXJzLmdpdGxhYi5jb22CD2dwcmQuZ2l0\nbGFiLmNvbYIOd3d3LmdpdGxhYi5jb20wDQYJKoZIhvcNAQELBQADggEBAD7lgx6z\ncZI+uLtr7fYWOZDtPChNy7YjAXVtDbrQ61D1lESUIZwyDF9/xCDMqMSe+It2+j+t\nT0PHkbz6zbJdUMQhQxW0RLMZUthPg66YLqRJuvBU7VdWHxhqjfFb9UZvxOzTGgmN\nMuzmdThtlhRacNCTxGO/AJfcAt13RbKyR30UtqHb883qAH6isQvYFsQmijXcJXiT\ntRbcJ1Dm/dI+57BCTYLp2WfBdg0Axla5QsApQ+ER5GZoY1m6H3+OWpX77IdCgXF+\nHMtKCn08QLVBjhLr3IkeKgrYJTR1IDmzRwGUuUVvn1iO9+W10GV02SMngdN4nFp3\nwoE3CsYogf1SfQM=\n-----END CERTIFICATE-----",
 				),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("argocd_certificate.simple", "https.0.server_name", serverName),
-					resource.TestCheckResourceAttr("argocd_certificate.simple", "https.0.cert_subtype", "rsa"),
-					resource.TestCheckResourceAttrSet("argocd_certificate.simple", "https.0.cert_info"),
+					resource.TestCheckResourceAttr("argocd_repository_certificate.simple", "https.0.server_name", serverName),
+					resource.TestCheckResourceAttr("argocd_repository_certificate.simple", "https.0.cert_subtype", "rsa"),
+					resource.TestCheckResourceAttrSet("argocd_repository_certificate.simple", "https.0.cert_info"),
 				),
 			},
 		},
@@ -281,14 +281,14 @@ func TestAccArgoCDRepositoryCertificatesHttps_CannotUpdateExisting_MultipleAtOnc
 
 func testAccArgoCDRepositoryCertificates_Empty() string {
 	return `
-resource "argocd_certificate" "simple" {
+resource "argocd_repository_certificate" "simple" {
 }
 `
 }
 
 func testAccArgoCDRepositoryCertificatesSSH(serverName, cert_subtype, cert_data string) string {
 	return fmt.Sprintf(`
-resource "argocd_certificate" "simple" {
+resource "argocd_repository_certificate" "simple" {
   ssh {
 	server_name  = "%s"
 	cert_subtype = "%s"
@@ -302,7 +302,7 @@ EOT
 
 func testAccArgoCDRepositoryCertificateSSH_Duplicated(serverName, cert_subtype, cert_data string) string {
 	return fmt.Sprintf(`
-resource "argocd_certificate" "simple" {
+resource "argocd_repository_certificate" "simple" {
   ssh {
 	server_name  = "%s"
 	cert_subtype = "%s"
@@ -312,7 +312,7 @@ EOT
   }
 }
 
-resource "argocd_certificate" "simple2" {
+resource "argocd_repository_certificate" "simple2" {
 	ssh {
 	  server_name  = "%s"
 	  cert_subtype = "%s"
@@ -326,7 +326,7 @@ resource "argocd_certificate" "simple2" {
 
 func testAccArgoCDRepositoryCertificateHttps(serverName, cert_data string) string {
 	return fmt.Sprintf(`
-resource "argocd_certificate" "simple" {
+resource "argocd_repository_certificate" "simple" {
   https {
     server_name  = "%s"
     cert_data    = <<EOT
@@ -339,7 +339,7 @@ EOT
 
 func testAccArgoCDRepositoryCertificateHttps_Duplicated(serverName, cert_data string) string {
 	return fmt.Sprintf(`
-resource "argocd_certificate" "simple" {
+resource "argocd_repository_certificate" "simple" {
   https {
     server_name  = "%s"
     cert_data    = <<EOT
@@ -348,7 +348,7 @@ EOT
   }
 }
 
-resource "argocd_certificate" "simple2" {
+resource "argocd_repository_certificate" "simple2" {
   https {
     server_name  = "%s"
     cert_data    = <<EOT
@@ -361,7 +361,7 @@ EOT
 
 func testAccArgoCDRepositoryCertificateCredentialsApplicationWithSSH(random string, subtypesKeys []string) string {
 	return fmt.Sprintf(`
-resource "argocd_certificate" "private-git-repository_0" {
+resource "argocd_repository_certificate" "private-git-repository_0" {
 	ssh {
 		server_name  = "private-git-repository.argocd.svc.cluster.local"
 		cert_subtype = "%s"
@@ -370,7 +370,7 @@ resource "argocd_certificate" "private-git-repository_0" {
 EOT
 	}
 }
-resource "argocd_certificate" "private-git-repository_1" {
+resource "argocd_repository_certificate" "private-git-repository_1" {
 	ssh {
 		server_name  = "private-git-repository.argocd.svc.cluster.local"
 		cert_subtype = "%s"
@@ -379,7 +379,7 @@ resource "argocd_certificate" "private-git-repository_1" {
 EOT
 	}
 }
-resource "argocd_certificate" "private-git-repository_2" {
+resource "argocd_repository_certificate" "private-git-repository_2" {
 	ssh {
 		server_name  = "private-git-repository.argocd.svc.cluster.local"
 		cert_subtype = "%s"
@@ -394,9 +394,9 @@ resource "argocd_repository" "private" {
   insecure   = false
   depends_on = [
 	  argocd_repository_credentials.private, 
-	  argocd_certificate.private-git-repository_0, 
-	  argocd_certificate.private-git-repository_1, 
-	  argocd_certificate.private-git-repository_2
+	  argocd_repository_certificate.private-git-repository_0, 
+	  argocd_repository_certificate.private-git-repository_1, 
+	  argocd_repository_certificate.private-git-repository_2
   ]
 }
  

--- a/argocd/resource_argocd_repository_certificates_test.go
+++ b/argocd/resource_argocd_repository_certificates_test.go
@@ -1,0 +1,115 @@
+package argocd
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccArgoCDRepositoryCertificates(t *testing.T) {
+	serverName := acctest.RandomWithPrefix("mywebsite")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccArgoCDRepositoryCertificateSimple(
+					serverName,
+					"ssh",
+					"ecdsa-sha2-nistp256",
+					// gitlab's
+					"AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFSMqzJeV9rUzU4kWitGjeR4PWSa29SPqJ1fVkhtj3Hw9xjLVXVYrU9QlYWrOLXBpQ6KWjbjTDTdDkoohFzgbEY=",
+				),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("argocd_certificate.simple", "server_name", serverName),
+					resource.TestCheckResourceAttrSet("argocd_certificate.simple", "cert_type"),
+					resource.TestCheckResourceAttrSet("argocd_certificate.simple", "cert_subtype"),
+					resource.TestCheckResourceAttrSet("argocd_certificate.simple", "cert_info"),
+				),
+			},
+			// same, no diff
+			{
+				Config: testAccArgoCDRepositoryCertificateSimple(
+					serverName,
+					"ssh",
+					"ecdsa-sha2-nistp256",
+					// gitlab's
+					"AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFSMqzJeV9rUzU4kWitGjeR4PWSa29SPqJ1fVkhtj3Hw9xjLVXVYrU9QlYWrOLXBpQ6KWjbjTDTdDkoohFzgbEY=",
+				),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+			// change only the cert_data => same id => diff
+			{
+				Config: testAccArgoCDRepositoryCertificateSimple(
+					serverName,
+					"ssh",
+					"ecdsa-sha2-nistp256",
+					// github's
+					"AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEmKSENjQEezOmxkZMy7opKgwFB9nkt5YRrYMjNuG5N87uRgg6CLrbo5wAdT/y6v0mKV0U2w0WZ2YB/++Tpockg=",
+				),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
+			// change cert_subtype & cert_data => changes id => diff
+			{
+				Config: testAccArgoCDRepositoryCertificateSimple(
+					serverName,
+					"ssh",
+					"ssh-rsa",
+					// github's
+					"AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==",
+				),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("argocd_certificate.simple", "server_name", serverName),
+					resource.TestCheckResourceAttrSet("argocd_certificate.simple", "cert_type"),
+					resource.TestCheckResourceAttrSet("argocd_certificate.simple", "cert_subtype"),
+				),
+			},
+			{
+				ResourceName:            "argocd_certificate.simple",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"cert_data"},
+				Destroy:                 true,
+			},
+		},
+	})
+}
+
+func TestAccArgoCDRepositoryCertificatesInvalid(t *testing.T) {
+	certType := acctest.RandomWithPrefix("cert")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccArgoCDRepositoryCertificateSimple(
+					"serverName",
+					certType,
+					"",
+					"",
+				),
+				ExpectError: regexp.MustCompile("mismatch: can only be https or ssh"),
+			},
+		},
+	})
+}
+
+func testAccArgoCDRepositoryCertificateSimple(serverName, cert_type, cert_subtype, cert_data string) string {
+	return fmt.Sprintf(`
+resource "argocd_certificate" "simple" {
+  server_name  = "%s"
+  cert_type    = "%s"
+  cert_subtype = "%s"
+  cert_data    = <<EOT
+%s
+EOT
+}
+`, serverName, cert_type, cert_subtype, cert_data)
+}

--- a/argocd/resource_argocd_repository_certificates_test.go
+++ b/argocd/resource_argocd_repository_certificates_test.go
@@ -188,7 +188,20 @@ func TestAccArgoCDRepositoryCertificatesInvalid(t *testing.T) {
 	})
 }
 
-func TestAccArgoCDRepositoryCertificatesSsh_Random_Subtype(t *testing.T) {
+func TestAccArgoCDRepositoryCertificatesEmpty(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccArgoCDRepositoryCertificateEmpty(),
+				ExpectError: regexp.MustCompile("one of `https,ssh` must be specified"),
+			},
+		},
+	})
+}
+
+func TestAccArgoCDRepositoryCertificatesSsh_Allow_Random_Subtype(t *testing.T) {
 	certSubType := acctest.RandomWithPrefix("cert")
 
 	resource.Test(t, resource.TestCase{
@@ -231,6 +244,13 @@ func TestAccArgoCDRepositoryCertificatesWithApplication(t *testing.T) {
 			},
 		},
 	})
+}
+
+func testAccArgoCDRepositoryCertificateEmpty() string {
+	return `
+resource "argocd_certificate" "simple" {
+}
+`
 }
 
 func testAccArgoCDRepositoryCertificateSSH(serverName, cert_subtype, cert_data string) string {

--- a/argocd/resource_argocd_repository_certificates_test.go
+++ b/argocd/resource_argocd_repository_certificates_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestAccArgoCDRepositoryCertificates(t *testing.T) {
+func TestAccArgoCDRepositoryCertificatesSsh(t *testing.T) {
 	serverName := acctest.RandomWithPrefix("mywebsite")
 
 	resource.Test(t, resource.TestCase{
@@ -17,25 +17,22 @@ func TestAccArgoCDRepositoryCertificates(t *testing.T) {
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccArgoCDRepositoryCertificateSimple(
+				Config: testAccArgoCDRepositoryCertificateSSH(
 					serverName,
-					"ssh",
 					"ecdsa-sha2-nistp256",
 					// gitlab's
 					"AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFSMqzJeV9rUzU4kWitGjeR4PWSa29SPqJ1fVkhtj3Hw9xjLVXVYrU9QlYWrOLXBpQ6KWjbjTDTdDkoohFzgbEY=",
 				),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("argocd_certificate.simple", "server_name", serverName),
-					resource.TestCheckResourceAttrSet("argocd_certificate.simple", "cert_type"),
-					resource.TestCheckResourceAttrSet("argocd_certificate.simple", "cert_subtype"),
-					resource.TestCheckResourceAttrSet("argocd_certificate.simple", "cert_info"),
+					resource.TestCheckResourceAttr("argocd_certificate.simple", "ssh.0.server_name", serverName),
+					resource.TestCheckResourceAttr("argocd_certificate.simple", "ssh.0.cert_subtype", "ecdsa-sha2-nistp256"),
+					resource.TestCheckResourceAttrSet("argocd_certificate.simple", "ssh.0.cert_info"),
 				),
 			},
 			// same, no diff
 			{
-				Config: testAccArgoCDRepositoryCertificateSimple(
+				Config: testAccArgoCDRepositoryCertificateSSH(
 					serverName,
-					"ssh",
 					"ecdsa-sha2-nistp256",
 					// gitlab's
 					"AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFSMqzJeV9rUzU4kWitGjeR4PWSa29SPqJ1fVkhtj3Hw9xjLVXVYrU9QlYWrOLXBpQ6KWjbjTDTdDkoohFzgbEY=",
@@ -45,9 +42,8 @@ func TestAccArgoCDRepositoryCertificates(t *testing.T) {
 			},
 			// change only the cert_data => same id => diff
 			{
-				Config: testAccArgoCDRepositoryCertificateSimple(
+				Config: testAccArgoCDRepositoryCertificateSSH(
 					serverName,
-					"ssh",
 					"ecdsa-sha2-nistp256",
 					// github's
 					"AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEmKSENjQEezOmxkZMy7opKgwFB9nkt5YRrYMjNuG5N87uRgg6CLrbo5wAdT/y6v0mKV0U2w0WZ2YB/++Tpockg=",
@@ -57,24 +53,106 @@ func TestAccArgoCDRepositoryCertificates(t *testing.T) {
 			},
 			// change cert_subtype & cert_data => changes id => diff
 			{
-				Config: testAccArgoCDRepositoryCertificateSimple(
+				Config: testAccArgoCDRepositoryCertificateSSH(
 					serverName,
-					"ssh",
 					"ssh-rsa",
 					// github's
 					"AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==",
 				),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("argocd_certificate.simple", "server_name", serverName),
-					resource.TestCheckResourceAttrSet("argocd_certificate.simple", "cert_type"),
-					resource.TestCheckResourceAttrSet("argocd_certificate.simple", "cert_subtype"),
+					resource.TestCheckResourceAttr("argocd_certificate.simple", "ssh.0.server_name", serverName),
+					resource.TestCheckResourceAttr("argocd_certificate.simple", "ssh.0.cert_subtype", "ssh-rsa"),
 				),
 			},
 			{
 				ResourceName:            "argocd_certificate.simple",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"cert_data"},
+				ImportStateVerifyIgnore: []string{"ssh.0.cert_data"},
+				Destroy:                 true,
+			},
+		},
+	})
+}
+
+func TestAccArgoCDRepositoryCertificatesHttps(t *testing.T) {
+	serverName := acctest.RandomWithPrefix("github")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccArgoCDRepositoryCertificateHttps(
+					serverName,
+					// github's
+					"-----BEGIN CERTIFICATE-----\nMIIFajCCBPCgAwIBAgIQBRiaVOvox+kD4KsNklVF3jAKBggqhkjOPQQDAzBWMQsw\nCQYDVQQGEwJVUzEVMBMGA1UEChMMRGlnaUNlcnQgSW5jMTAwLgYDVQQDEydEaWdp\nQ2VydCBUTFMgSHlicmlkIEVDQyBTSEEzODQgMjAyMCBDQTEwHhcNMjIwMzE1MDAw\nMDAwWhcNMjMwMzE1MjM1OTU5WjBmMQswCQYDVQQGEwJVUzETMBEGA1UECBMKQ2Fs\naWZvcm5pYTEWMBQGA1UEBxMNU2FuIEZyYW5jaXNjbzEVMBMGA1UEChMMR2l0SHVi\nLCBJbmMuMRMwEQYDVQQDEwpnaXRodWIuY29tMFkwEwYHKoZIzj0CAQYIKoZIzj0D\nAQcDQgAESrCTcYUh7GI/y3TARsjnANwnSjJLitVRgwgRI1JlxZ1kdZQQn5ltP3v7\nKTtYuDdUeEu3PRx3fpDdu2cjMlyA0aOCA44wggOKMB8GA1UdIwQYMBaAFAq8CCkX\njKU5bXoOzjPHLrPt+8N6MB0GA1UdDgQWBBR4qnLGcWloFLVZsZ6LbitAh0I7HjAl\nBgNVHREEHjAcggpnaXRodWIuY29tgg53d3cuZ2l0aHViLmNvbTAOBgNVHQ8BAf8E\nBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMIGbBgNVHR8EgZMw\ngZAwRqBEoEKGQGh0dHA6Ly9jcmwzLmRpZ2ljZXJ0LmNvbS9EaWdpQ2VydFRMU0h5\nYnJpZEVDQ1NIQTM4NDIwMjBDQTEtMS5jcmwwRqBEoEKGQGh0dHA6Ly9jcmw0LmRp\nZ2ljZXJ0LmNvbS9EaWdpQ2VydFRMU0h5YnJpZEVDQ1NIQTM4NDIwMjBDQTEtMS5j\ncmwwPgYDVR0gBDcwNTAzBgZngQwBAgIwKTAnBggrBgEFBQcCARYbaHR0cDovL3d3\ndy5kaWdpY2VydC5jb20vQ1BTMIGFBggrBgEFBQcBAQR5MHcwJAYIKwYBBQUHMAGG\nGGh0dHA6Ly9vY3NwLmRpZ2ljZXJ0LmNvbTBPBggrBgEFBQcwAoZDaHR0cDovL2Nh\nY2VydHMuZGlnaWNlcnQuY29tL0RpZ2lDZXJ0VExTSHlicmlkRUNDU0hBMzg0MjAy\nMENBMS0xLmNydDAJBgNVHRMEAjAAMIIBfwYKKwYBBAHWeQIEAgSCAW8EggFrAWkA\ndgCt9776fP8QyIudPZwePhhqtGcpXc+xDCTKhYY069yCigAAAX+Oi8SRAAAEAwBH\nMEUCIAR9cNnvYkZeKs9JElpeXwztYB2yLhtc8bB0rY2ke98nAiEAjiML8HZ7aeVE\nP/DkUltwIS4c73VVrG9JguoRrII7gWMAdwA1zxkbv7FsV78PrUxtQsu7ticgJlHq\nP+Eq76gDwzvWTAAAAX+Oi8R7AAAEAwBIMEYCIQDNckqvBhup7GpANMf0WPueytL8\nu/PBaIAObzNZeNMpOgIhAMjfEtE6AJ2fTjYCFh/BNVKk1mkTwBTavJlGmWomQyaB\nAHYAs3N3B+GEUPhjhtYFqdwRCUp5LbFnDAuH3PADDnk2pZoAAAF/jovErAAABAMA\nRzBFAiEA9Uj5Ed/XjQpj/MxQRQjzG0UFQLmgWlc73nnt3CJ7vskCICqHfBKlDz7R\nEHdV5Vk8bLMBW1Q6S7Ga2SbFuoVXs6zFMAoGCCqGSM49BAMDA2gAMGUCMCiVhqft\n7L/stBmv1XqSRNfE/jG/AqKIbmjGTocNbuQ7kt1Cs7kRg+b3b3C9Ipu5FQIxAM7c\ntGKrYDGt0pH8iF6rzbp9Q4HQXMZXkNxg+brjWxnaOVGTDNwNH7048+s/hT9bUQ==\n-----END CERTIFICATE-----",
+				),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("argocd_certificate.simple", "https.0.server_name", serverName),
+					resource.TestCheckResourceAttr("argocd_certificate.simple", "https.0.cert_subtype", "ecdsa"),
+					resource.TestCheckResourceAttrSet("argocd_certificate.simple", "https.0.cert_info"),
+				),
+			},
+			{
+				Config: testAccArgoCDRepositoryCertificateHttps(
+					serverName,
+					// gitlab's
+					"-----BEGIN CERTIFICATE-----\nMIIGBzCCBO+gAwIBAgIQXCLSMilzZJR9TSABzbgKzzANBgkqhkiG9w0BAQsFADCB\njzELMAkGA1UEBhMCR0IxGzAZBgNVBAgTEkdyZWF0ZXIgTWFuY2hlc3RlcjEQMA4G\nA1UEBxMHU2FsZm9yZDEYMBYGA1UEChMPU2VjdGlnbyBMaW1pdGVkMTcwNQYDVQQD\nEy5TZWN0aWdvIFJTQSBEb21haW4gVmFsaWRhdGlvbiBTZWN1cmUgU2VydmVyIENB\nMB4XDTIxMDQxMjAwMDAwMFoXDTIyMDUxMTIzNTk1OVowFTETMBEGA1UEAxMKZ2l0\nbGFiLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBANXnhcvOl289\n8oMglaax6bDz988oNMpXZCH6sI7Fzx9G/isEPObN6cyP+fjFa0dvwRmOHnepk2eo\nbzcECdgdBLCa7E29p7lLF0NFFTuIb52ew58fK/209XJ3amvjJ/m5rPP00uHrT+9v\nky2jkQUQszuC9R4vK+tfs2S5z9w6qh3hwIJecChzWKce8hRZdiO9S7ix/6ZNiAgw\nY2h8AiG0VruPOJ6PbNXOFUTsajK0EP8AzJfNDIjvWHjUOawR352m4eKxXvXm9knd\nB/w1gY90jmAQ9JIiyOm+QlmHwO+qQUpWYOxt5Xnb0Pp/RRHEtxDgjygQWajAwsxG\nobx6sCf6+qcCAwEAAaOCAtYwggLSMB8GA1UdIwQYMBaAFI2MXsRUrYrhd+mb+ZsF\n4bgBjWHhMB0GA1UdDgQWBBTFjbuGoOUrgk9Dhr35DblkBZCj1jAOBgNVHQ8BAf8E\nBAMCBaAwDAYDVR0TAQH/BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUH\nAwIwSQYDVR0gBEIwQDA0BgsrBgEEAbIxAQICBzAlMCMGCCsGAQUFBwIBFhdodHRw\nczovL3NlY3RpZ28uY29tL0NQUzAIBgZngQwBAgEwgYQGCCsGAQUFBwEBBHgwdjBP\nBggrBgEFBQcwAoZDaHR0cDovL2NydC5zZWN0aWdvLmNvbS9TZWN0aWdvUlNBRG9t\nYWluVmFsaWRhdGlvblNlY3VyZVNlcnZlckNBLmNydDAjBggrBgEFBQcwAYYXaHR0\ncDovL29jc3Auc2VjdGlnby5jb20wggEEBgorBgEEAdZ5AgQCBIH1BIHyAPAAdgBG\npVXrdfqRIDC1oolp9PN9ESxBdL79SbiFq/L8cP5tRwAAAXjDcW8TAAAEAwBHMEUC\nIQCxf+r8/dbHJDrh0YTAKSwdR8VUxAT6kHN5/HLuOvSsKgIgY2jAAf/tr59/f0JX\nKvHaN4qIv54gtj+KsNo7N0d4xcEAdgDfpV6raIJPH2yt7rhfTj5a6s2iEqRqXo47\nEsAgRFwqcwAAAXjDcW7VAAAEAwBHMEUCID0jtWvtpO1yypP7i7SeZZb3dQ6QdLlD\nlXpvWhjqrQfdAiEA0gp8tTUwOt2XN01OVTUrDgb4wV5VbFtx1SSYNFREQxwweQYD\nVR0RBHIwcIIKZ2l0bGFiLmNvbYIPYXV0aC5naXRsYWIuY29tghRjdXN0b21lcnMu\nZ2l0bGFiLmNvbYIaZW1haWwuY3VzdG9tZXJzLmdpdGxhYi5jb22CD2dwcmQuZ2l0\nbGFiLmNvbYIOd3d3LmdpdGxhYi5jb20wDQYJKoZIhvcNAQELBQADggEBAD7lgx6z\ncZI+uLtr7fYWOZDtPChNy7YjAXVtDbrQ61D1lESUIZwyDF9/xCDMqMSe+It2+j+t\nT0PHkbz6zbJdUMQhQxW0RLMZUthPg66YLqRJuvBU7VdWHxhqjfFb9UZvxOzTGgmN\nMuzmdThtlhRacNCTxGO/AJfcAt13RbKyR30UtqHb883qAH6isQvYFsQmijXcJXiT\ntRbcJ1Dm/dI+57BCTYLp2WfBdg0Axla5QsApQ+ER5GZoY1m6H3+OWpX77IdCgXF+\nHMtKCn08QLVBjhLr3IkeKgrYJTR1IDmzRwGUuUVvn1iO9+W10GV02SMngdN4nFp3\nwoE3CsYogf1SfQM=\n-----END CERTIFICATE-----",
+				),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("argocd_certificate.simple", "https.0.server_name", serverName),
+					resource.TestCheckResourceAttr("argocd_certificate.simple", "https.0.cert_subtype", "rsa"),
+					resource.TestCheckResourceAttrSet("argocd_certificate.simple", "https.0.cert_info"),
+				),
+			},
+			{
+				ResourceName:            "argocd_certificate.simple",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"https.0.cert_data"},
+				Destroy:                 true,
+			},
+		},
+	})
+}
+
+func TestAccArgoCDRepositoryCertificatesHttpsCrash(t *testing.T) {
+	serverName := acctest.RandomWithPrefix("github")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccArgoCDRepositoryCertificateHttps(
+					serverName,
+					// github's
+					"-----BEGIN CERTIFICATE-----\nMIIFajCCBPCgAwIBAgIQBRiaVOvox+kD4KsNklVF3jAKBggqhkjOPQQDAzBWMQsw\nCQYDVQQGEwJVUzEVMBMGA1UEChMMRGlnaUNlcnQgSW5jMTAwLgYDVQQDEydEaWdp\nQ2VydCBUTFMgSHlicmlkIEVDQyBTSEEzODQgMjAyMCBDQTEwHhcNMjIwMzE1MDAw\nMDAwWhcNMjMwMzE1MjM1OTU5WjBmMQswCQYDVQQGEwJVUzETMBEGA1UECBMKQ2Fs\naWZvcm5pYTEWMBQGA1UEBxMNU2FuIEZyYW5jaXNjbzEVMBMGA1UEChMMR2l0SHVi\nLCBJbmMuMRMwEQYDVQQDEwpnaXRodWIuY29tMFkwEwYHKoZIzj0CAQYIKoZIzj0D\nAQcDQgAESrCTcYUh7GI/y3TARsjnANwnSjJLitVRgwgRI1JlxZ1kdZQQn5ltP3v7\nKTtYuDdUeEu3PRx3fpDdu2cjMlyA0aOCA44wggOKMB8GA1UdIwQYMBaAFAq8CCkX\njKU5bXoOzjPHLrPt+8N6MB0GA1UdDgQWBBR4qnLGcWloFLVZsZ6LbitAh0I7HjAl\nBgNVHREEHjAcggpnaXRodWIuY29tgg53d3cuZ2l0aHViLmNvbTAOBgNVHQ8BAf8E\nBAMCB4AwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMIGbBgNVHR8EgZMw\ngZAwRqBEoEKGQGh0dHA6Ly9jcmwzLmRpZ2ljZXJ0LmNvbS9EaWdpQ2VydFRMU0h5\nYnJpZEVDQ1NIQTM4NDIwMjBDQTEtMS5jcmwwRqBEoEKGQGh0dHA6Ly9jcmw0LmRp\nZ2ljZXJ0LmNvbS9EaWdpQ2VydFRMU0h5YnJpZEVDQ1NIQTM4NDIwMjBDQTEtMS5j\ncmwwPgYDVR0gBDcwNTAzBgZngQwBAgIwKTAnBggrBgEFBQcCARYbaHR0cDovL3d3\ndy5kaWdpY2VydC5jb20vQ1BTMIGFBggrBgEFBQcBAQR5MHcwJAYIKwYBBQUHMAGG\nGGh0dHA6Ly9vY3NwLmRpZ2ljZXJ0LmNvbTBPBggrBgEFBQcwAoZDaHR0cDovL2Nh\nY2VydHMuZGlnaWNlcnQuY29tL0RpZ2lDZXJ0VExTSHlicmlkRUNDU0hBMzg0MjAy\nMENBMS0xLmNydDAJBgNVHRMEAjAAMIIBfwYKKwYBBAHWeQIEAgSCAW8EggFrAWkA\ndgCt9776fP8QyIudPZwePhhqtGcpXc+xDCTKhYY069yCigAAAX+Oi8SRAAAEAwBH\nMEUCIAR9cNnvYkZeKs9JElpeXwztYB2yLhtc8bB0rY2ke98nAiEAjiML8HZ7aeVE\nP/DkUltwIS4c73VVrG9JguoRrII7gWMAdwA1zxkbv7FsV78PrUxtQsu7ticgJlHq\nP+Eq76gDwzvWTAAAAX+Oi8R7AAAEAwBIMEYCIQDNckqvBhup7GpANMf0WPueytL8\nu/PBaIAObzNZeNMpOgIhAMjfEtE6AJ2fTjYCFh/BNVKk1mkTwBTavJlGmWomQyaB\nAHYAs3N3B+GEUPhjhtYFqdwRCUp5LbFnDAuH3PADDnk2pZoAAAF/jovErAAABAMA\nRzBFAiEA9Uj5Ed/XjQpj/MxQRQjzG0UFQLmgWlc73nnt3CJ7vskCICqHfBKlDz7R\nEHdV5Vk8bLMBW1Q6S7Ga2SbFuoVXs6zFMAoGCCqGSM49BAMDA2gAMGUCMCiVhqft\n7L/stBmv1XqSRNfE/jG/AqKIbmjGTocNbuQ7kt1Cs7kRg+b3b3C9Ipu5FQIxAM7c\ntGKrYDGt0pH8iF6rzbp9Q4HQXMZXkNxg+brjWxnaOVGTDNwNH7048+s/hT9bUQ==\n-----END CERTIFICATE-----",
+				),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("argocd_certificate.simple", "https.0.server_name", serverName),
+					resource.TestCheckResourceAttr("argocd_certificate.simple", "https.0.cert_subtype", "ecdsa"),
+					resource.TestCheckResourceAttrSet("argocd_certificate.simple", "https.0.cert_info"),
+				),
+			},
+			{
+				Config: testAccArgoCDRepositoryCertificateHttps(
+					serverName,
+					// gitlab's
+					"-----BEGIN CERTIFICATE-----\nMIIGBzCCBO+gAwIBAgIQXCLSMilzZJR9TSABzbgKzzANBgkqhkiG9w0BAQsFADCB\njzELMAkGA1UEBhMCR0IxGzAZBgNVBAgTEkdyZWF0ZXIgTWFuY2hlc3RlcjEQMA4G\nA1UEBxMHU2FsZm9yZDEYMBYGA1UEChMPU2VjdGlnbyBMaW1pdGVkMTcwNQYDVQQD\nEy5TZWN0aWdvIFJTQSBEb21haW4gVmFsaWRhdGlvbiBTZWN1cmUgU2VydmVyIENB\nMB4XDTIxMDQxMjAwMDAwMFoXDTIyMDUxMTIzNTk1OVowFTETMBEGA1UEAxMKZ2l0\nbGFiLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBANXnhcvOl289\n8oMglaax6bDz988oNMpXZCH6sI7Fzx9G/isEPObN6cyP+fjFa0dvwRmOHnepk2eo\nbzcECdgdBLCa7E29p7lLF0NFFTuIb52ew58fK/209XJ3amvjJ/m5rPP00uHrT+9v\nky2jkQUQszuC9R4vK+tfs2S5z9w6qh3hwIJecChzWKce8hRZdiO9S7ix/6ZNiAgw\nY2h8AiG0VruPOJ6PbNXOFUTsajK0EP8AzJfNDIjvWHjUOawR352m4eKxXvXm9knd\nB/w1gY90jmAQ9JIiyOm+QlmHwO+qQUpWYOxt5Xnb0Pp/RRHEtxDgjygQWajAwsxG\nobx6sCf6+qcCAwEAAaOCAtYwggLSMB8GA1UdIwQYMBaAFI2MXsRUrYrhd+mb+ZsF\n4bgBjWHhMB0GA1UdDgQWBBTFjbuGoOUrgk9Dhr35DblkBZCj1jAOBgNVHQ8BAf8E\nBAMCBaAwDAYDVR0TAQH/BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUH\nAwIwSQYDVR0gBEIwQDA0BgsrBgEEAbIxAQICBzAlMCMGCCsGAQUFBwIBFhdodHRw\nczovL3NlY3RpZ28uY29tL0NQUzAIBgZngQwBAgEwgYQGCCsGAQUFBwEBBHgwdjBP\nBggrBgEFBQcwAoZDaHR0cDovL2NydC5zZWN0aWdvLmNvbS9TZWN0aWdvUlNBRG9t\nYWluVmFsaWRhdGlvblNlY3VyZVNlcnZlckNBLmNydDAjBggrBgEFBQcwAYYXaHR0\ncDovL29jc3Auc2VjdGlnby5jb20wggEEBgorBgEEAdZ5AgQCBIH1BIHyAPAAdgBG\npVXrdfqRIDC1oolp9PN9ESxBdL79SbiFq/L8cP5tRwAAAXjDcW8TAAAEAwBHMEUC\nIQCxf+r8/dbHJDrh0YTAKSwdR8VUxAT6kHN5/HLuOvSsKgIgY2jAAf/tr59/f0JX\nKvHaN4qIv54gtj+KsNo7N0d4xcEAdgDfpV6raIJPH2yt7rhfTj5a6s2iEqRqXo47\nEsAgRFwqcwAAAXjDcW7VAAAEAwBHMEUCID0jtWvtpO1yypP7i7SeZZb3dQ6QdLlD\nlXpvWhjqrQfdAiEA0gp8tTUwOt2XN01OVTUrDgb4wV5VbFtx1SSYNFREQxwweQYD\nVR0RBHIwcIIKZ2l0bGFiLmNvbYIPYXV0aC5naXRsYWIuY29tghRjdXN0b21lcnMu\nZ2l0bGFiLmNvbYIaZW1haWwuY3VzdG9tZXJzLmdpdGxhYi5jb22CD2dwcmQuZ2l0\nbGFiLmNvbYIOd3d3LmdpdGxhYi5jb20wDQYJKoZIhvcNAQELBQADggEBAD7lgx6z\ncZI+uLtr7fYWOZDtPChNy7YjAXVtDbrQ61D1lESUIZwyDF9/xCDMqMSe+It2+j+t\nT0PHkbz6zbJdUMQhQxW0RLMZUthPg66YLqRJuvBU7VdWHxhqjfFb9UZvxOzTGgmN\nMuzmdThtlhRacNCTxGO/AJfcAt13RbKyR30UtqHb883qAH6isQvYFsQmijXcJXiT\ntRbcJ1Dm/dI+57BCTYLp2WfBdg0Axla5QsApQ+ER5GZoY1m6H3+OWpX77IdCgXF+\nHMtKCn08QLVBjhLr3IkeKgrYJTR1IDmzRwGUuUVvn1iO9+W10GV02SMngdN4nFp3\nwoE3CsYogf1SfQM=\n-----END CERTIFICATE-----",
+				),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("argocd_certificate.simple", "https.0.server_name", serverName),
+					resource.TestCheckResourceAttr("argocd_certificate.simple", "https.0.cert_subtype", "rsa"),
+					resource.TestCheckResourceAttrSet("argocd_certificate.simple", "https.0.cert_info"),
+				),
+			},
+			{
+				ResourceName:            "argocd_certificate.simple",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"https.0.cert_data"},
 				Destroy:                 true,
 			},
 		},
@@ -82,34 +160,170 @@ func TestAccArgoCDRepositoryCertificates(t *testing.T) {
 }
 
 func TestAccArgoCDRepositoryCertificatesInvalid(t *testing.T) {
-	certType := acctest.RandomWithPrefix("cert")
+	certSubType := acctest.RandomWithPrefix("cert")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccArgoCDRepositoryCertificateSimple(
-					"serverName",
-					certType,
+				Config: testAccArgoCDRepositoryCertificateSSH(
 					"",
+					certSubType,
 					"",
 				),
-				ExpectError: regexp.MustCompile("mismatch: can only be https or ssh"),
+				ExpectError: regexp.MustCompile("Invalid hostname in request"),
+			},
+			{
+				Config: testAccArgoCDRepositoryCertificateSSH(
+					"dummy_server",
+					certSubType,
+					"",
+				),
+				ExpectError: regexp.MustCompile("invalid entry in known_hosts data"),
 			},
 		},
 	})
 }
 
-func testAccArgoCDRepositoryCertificateSimple(serverName, cert_type, cert_subtype, cert_data string) string {
+func TestAccArgoCDRepositoryCertificatesSsh_Random_Subtype(t *testing.T) {
+	certSubType := acctest.RandomWithPrefix("cert")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccArgoCDRepositoryCertificateSSH(
+					"dummy_server",
+					certSubType,
+					"AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFSMqzJeV9rUzU4kWitGjeR4PWSa29SPqJ1fVkhtj3Hw9xjLVXVYrU9QlYWrOLXBpQ6KWjbjTDTdDkoohFzgbEY=",
+				),
+			},
+		},
+	})
+}
+
+// func TestAccArgoCDRepositoryCertifcateCredentialsApplicationWithSSH(t *testing.T) {
+// 	appName := acctest.RandomWithPrefix("testacc")
+
+// 	resource.Test(t, resource.TestCase{
+// 		PreCheck:          func() { testAccPreCheck(t) },
+// 		ProviderFactories: testAccProviders,
+// 		Steps: []resource.TestStep{
+// 			{
+// 				Config: testAccArgoCDRepositoryCertificateCredentialsApplicationWithSSH(appName),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					resource.TestCheckResourceAttrSet(
+// 						"argocd_application.simple",
+// 						"metadata.0.uid",
+// 					),
+// 					resource.TestCheckResourceAttr(
+// 						"argocd_repository.private",
+// 						"connection_state_status",
+// 						"Successful",
+// 					)),
+// 			},
+// 		},
+// 	})
+// }
+
+func testAccArgoCDRepositoryCertificateSSH(serverName, cert_subtype, cert_data string) string {
 	return fmt.Sprintf(`
 resource "argocd_certificate" "simple" {
-  server_name  = "%s"
-  cert_type    = "%s"
-  cert_subtype = "%s"
-  cert_data    = <<EOT
+  ssh {
+	server_name  = "%s"
+	cert_subtype = "%s"
+	cert_data    = <<EOT
 %s
 EOT
+  }
 }
-`, serverName, cert_type, cert_subtype, cert_data)
+`, serverName, cert_subtype, cert_data)
+}
+
+func testAccArgoCDRepositoryCertificateHttps(serverName, cert_data string) string {
+	return fmt.Sprintf(`
+resource "argocd_certificate" "simple" {
+  https {
+    server_name  = "%s"
+    cert_data    = <<EOT
+%s
+EOT
+  }
+}
+`, serverName, cert_data)
+}
+
+func testAccArgoCDRepositoryCertificateCredentialsApplicationWithSSH(random string) string {
+	return fmt.Sprintf(`
+resource "argocd_certificate" "private-git-repository_ssh-rsa" {
+	server_name  = "private-git-repository.argocd.svc.cluster.local"
+	cert_type    = "ssh"
+	cert_subtype = "ssh-rsa"
+	cert_data    = <<EOT
+	AAAAB3NzaC1yc2EAAAADAQABAAABgQDPR/4BO1X7ehl29eJnKV95Qup9KZEzszrAWirR753ZN8/eQXrv4FTdVnHWEAzPPbw8fsLOEr1b/pzrvlPY7YFB5D39Vd9fG7XNi7E9c8Tm2dfoXy2sYD+iweeY5T4wThkNDGkuFSqbxSv07TuPYUjnhWBy3eAAL8ufX5raajs2+BkIi8cDSGz0eCHYvt/hpLc9/HATpaslOA8QC4LgqyQu73q9jVZm0DYZTtPXdHgT728hwq6/ZctREpQdiY7bbAGQnOQ/qAtyRw0usI4HHJeGGxp+WfwzyaIF+xwhBOtetW8tm1OOHbIT3ox18tun8lEG55nudFBuPlxNfuK9DD6CLpQvE8JbbWn/zIc+ia3pe+sMU8qFA7P/V80r1xE/g2rKlzVqrOg8SVjqt1RKNIplL3PCqJpSwIeXlfFbDRNRDYO8SKjpV40GmQEfXUpYOOdywZIGG8C8+JfV16vKabovLq5+vdgeSTerkNe451xx6u/5zsw1R5msRmtWjPxPYlc=
+EOT
+}
+resource "argocd_certificate" "private-git-repository_ssh-ecdsa" {
+	server_name  = "private-git-repository.argocd.svc.cluster.local"
+	cert_type    = "ssh"
+	cert_subtype = "ecdsa-sha2-nistp256"
+	cert_data    = <<EOT
+	AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBNrROc04E599+H2fO5Dqv8GOa3M0ZCUYWW1vUmeB5re56Cw77smSmpAFEK03H8fQDq4ucUvOYnpr7n9OqbVdiTk=
+EOT
+}
+resource "argocd_certificate" "private-git-repository_ssh-ed25519" {
+	server_name  = "private-git-repository.argocd.svc.cluster.local"
+	cert_type    = "ssh"
+	cert_subtype = "ssh-ed25519"
+	cert_data    = <<EOT
+	AAAAC3NzaC1lZDI1NTE5AAAAIAGBu8KvIUJ9OEzpHiEsnLV5EjhiFQP0GWTc+aI9inZK
+EOT
+
+	# ssh knownhost takes some time to be applied by argocd, blindly waiting 90s for the key to be taken in account
+	provisioner "local-exec" {
+		command = "sleep 90"
+	}
+}
+
+resource "argocd_repository" "private" {
+  repo       = "git@private-git-repository.argocd.svc.cluster.local:~/project-1.git"
+  insecure   = false
+  depends_on = [
+	  argocd_repository_credentials.private, 
+	  argocd_certificate.private-git-repository_ssh-rsa, 
+	  argocd_certificate.private-git-repository_ssh-ecdsa, 
+	  argocd_certificate.private-git-repository_ssh-ed25519
+  ]
+}
+ 
+resource "argocd_repository_credentials" "private" {
+  url             = "git@private-git-repository.argocd.svc.cluster.local"
+  username        = "git"
+  ssh_private_key = "-----BEGIN OPENSSH PRIVATE KEY-----\nb3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW\nQyNTUxOQAAACCGe6Vx0gbKqKCI0wIplfgK5JBjCDO3bhtU3sZfLoeUZgAAAJB9cNEifXDR\nIgAAAAtzc2gtZWQyNTUxOQAAACCGe6Vx0gbKqKCI0wIplfgK5JBjCDO3bhtU3sZfLoeUZg\nAAAEAJeUrObjoTbGO1Sq4TXHl/j4RJ5aKMC1OemWuHmLK7XYZ7pXHSBsqooIjTAimV+Ark\nkGMIM7duG1Texl8uh5RmAAAAC3Rlc3RAYXJnb2NkAQI=\n-----END OPENSSH PRIVATE KEY-----"
+}
+
+resource "argocd_application" "simple" {
+  metadata {
+    name      = "%s"
+    namespace = "argocd"
+    labels = {
+      acceptance = "true"
+    }
+  }
+
+  spec {
+    source {
+      repo_url        = argocd_repository.private.repo
+	  path = "."
+    }
+
+    destination {
+      server    = "https://kubernetes.default.svc"
+      namespace = "default"
+    }
+  }
+}
+`, random)
 }

--- a/argocd/schema_repository_certificates.go
+++ b/argocd/schema_repository_certificates.go
@@ -1,0 +1,41 @@
+package argocd
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func certificatesSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"server_name": {
+			Type:        schema.TypeString,
+			Description: "ServerName specifies the DNS name of the server this certificate is intended for",
+			Required:    true,
+			ForceNew:    true,
+		},
+		"cert_type": {
+			Type:         schema.TypeString,
+			Description:  "CertType specifies the type of the certificate - currently one of `https` or `ssh`",
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validateCertificateType,
+		},
+		"cert_subtype": {
+			Type:        schema.TypeString,
+			Description: "SubType specifies the sub type of the cert, i.e. `ssh-rsa`",
+			Required:    true,
+			ForceNew:    true,
+		},
+		"cert_data": {
+			Type:        schema.TypeString,
+			Sensitive:   true,
+			Description: "CertData contains the actual certificate data, dependent on the certificate type",
+			Required:    true,
+			ForceNew:    true,
+		},
+		"cert_info": {
+			Type:        schema.TypeString,
+			Description: "CertInfo will hold additional certificate info, dependent on the certificate type (e.g. SSH fingerprint, X509 CommonName)",
+			Computed:    true,
+		},
+	}
+}

--- a/argocd/schema_repository_certificates.go
+++ b/argocd/schema_repository_certificates.go
@@ -6,36 +6,76 @@ import (
 
 func certificatesSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
-		"server_name": {
-			Type:        schema.TypeString,
-			Description: "ServerName specifies the DNS name of the server this certificate is intended for",
-			Required:    true,
-			ForceNew:    true,
+		"ssh": {
+			Type:          schema.TypeList,
+			Optional:      true,
+			ForceNew:      true,
+			MaxItems:      1,
+			Description:   "Defines a ssh certificate.",
+			ConflictsWith: []string{"https"},
+			AtLeastOneOf:  []string{"https", "ssh"},
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"server_name": {
+						Type:        schema.TypeString,
+						Description: "ServerName specifies the DNS name of the server this certificate is intended for",
+						Required:    true,
+						ForceNew:    true,
+					},
+					"cert_subtype": {
+						Type:        schema.TypeString,
+						Description: "SubType specifies the sub type of the cert, i.e. `ssh-rsa`",
+						Required:    true,
+						ForceNew:    true,
+					},
+					"cert_data": {
+						Type:        schema.TypeString,
+						Description: "CertData contains the actual certificate data, dependent on the certificate type",
+						Required:    true,
+						ForceNew:    true,
+					},
+					"cert_info": {
+						Type:        schema.TypeString,
+						Description: "CertInfo will hold additional certificate info, dependent on the certificate type (e.g. SSH fingerprint, X509 CommonName)",
+						Computed:    true,
+					},
+				},
+			},
 		},
-		"cert_type": {
-			Type:         schema.TypeString,
-			Description:  "CertType specifies the type of the certificate - currently one of `https` or `ssh`",
-			Required:     true,
-			ForceNew:     true,
-			ValidateFunc: validateCertificateType,
-		},
-		"cert_subtype": {
-			Type:        schema.TypeString,
-			Description: "SubType specifies the sub type of the cert, i.e. `ssh-rsa`",
-			Required:    true,
-			ForceNew:    true,
-		},
-		"cert_data": {
-			Type:        schema.TypeString,
-			Sensitive:   true,
-			Description: "CertData contains the actual certificate data, dependent on the certificate type",
-			Required:    true,
-			ForceNew:    true,
-		},
-		"cert_info": {
-			Type:        schema.TypeString,
-			Description: "CertInfo will hold additional certificate info, dependent on the certificate type (e.g. SSH fingerprint, X509 CommonName)",
-			Computed:    true,
+		"https": {
+			Type:          schema.TypeList,
+			Optional:      true,
+			ForceNew:      true,
+			MaxItems:      1,
+			ConflictsWith: []string{"ssh"},
+			AtLeastOneOf:  []string{"https", "ssh"},
+			Description:   "Defines a https certificate.",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"server_name": {
+						Type:        schema.TypeString,
+						Description: "ServerName specifies the DNS name of the server this certificate is intended for",
+						Required:    true,
+						ForceNew:    true,
+					},
+					"cert_data": {
+						Type:        schema.TypeString,
+						Description: "CertData contains the actual certificate data, dependent on the certificate type",
+						Required:    true,
+						ForceNew:    true,
+					},
+					"cert_subtype": {
+						Type:        schema.TypeString,
+						Description: "SubType specifies the sub type of the cert, i.e. `ssh-rsa`",
+						Computed:    true,
+					},
+					"cert_info": {
+						Type:        schema.TypeString,
+						Description: "CertInfo will hold additional certificate info, dependent on the certificate type (e.g. SSH fingerprint, X509 CommonName)",
+						Computed:    true,
+					},
+				},
+			},
 		},
 	}
 }

--- a/argocd/structure_repository_certificate.go
+++ b/argocd/structure_repository_certificate.go
@@ -1,7 +1,7 @@
 package argocd
 
 import (
-	"fmt"
+	"context"
 
 	application "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 
@@ -12,42 +12,76 @@ import (
 
 func expandRepositoryCertificate(d *schema.ResourceData) (*application.RepositoryCertificate, error) {
 	certificate := &application.RepositoryCertificate{}
-	if v, ok := d.GetOk("server_name"); ok {
-		certificate.ServerName = v.(string)
-	}
-	if v, ok := d.GetOk("cert_type"); ok {
-		certType := v.(string)
-		if certType != "ssh" && certType != "https" {
-			return nil, fmt.Errorf("invalid certificate type '%s': must be either ssh or https", certType)
+
+	if _, ok := d.GetOk("ssh"); ok {
+		certificate.CertType = "ssh"
+		if v, ok := d.GetOk("ssh.0.server_name"); ok {
+			certificate.ServerName = v.(string)
 		}
-		certificate.CertType = v.(string)
-	}
-	if v, ok := d.GetOk("cert_subtype"); ok {
-		certificate.CertSubType = v.(string)
-	}
-	if v, ok := d.GetOk("cert_data"); ok {
-		certificate.CertData = []byte(v.(string))
-	}
-	if v, ok := d.GetOk("cert_info"); ok {
-		certificate.CertInfo = v.(string)
+		if v, ok := d.GetOk("ssh.0.cert_subtype"); ok {
+			certificate.CertSubType = v.(string)
+		}
+		if v, ok := d.GetOk("ssh.0.cert_data"); ok {
+			certificate.CertData = []byte(v.(string))
+		}
+	} else if _, ok := d.GetOk("https"); ok {
+		certificate.CertType = "https"
+		if v, ok := d.GetOk("https.0.server_name"); ok {
+			certificate.ServerName = v.(string)
+		}
+		if v, ok := d.GetOk("https.0.cert_data"); ok {
+			certificate.CertData = []byte(v.(string))
+		}
 	}
 	return certificate, nil
 }
 
 // Flatten
 
-func flattenRepositoryCertificate(certificate *application.RepositoryCertificate, d *schema.ResourceData) error {
-	r := map[string]interface{}{
-		"server_name":  certificate.ServerName,
-		"cert_type":    certificate.CertType,
-		"cert_subtype": certificate.CertSubType,
-		"cert_info":    certificate.CertInfo,
-		// "cert_data": certificate.CertData,  ArgoCD API does not return sensitive data!
+func flattenRepositoryCertificate(certificate *application.RepositoryCertificate, d *schema.ResourceData, ctx context.Context) error {
+	var r map[string]interface{}
+
+	if certificate.CertType == "ssh" {
+		r = map[string]interface{}{
+			"ssh": []map[string]string{
+				{
+					"server_name":  certificate.ServerName,
+					"cert_subtype": certificate.CertSubType,
+					"cert_info":    certificate.CertInfo,
+					"cert_data":    getCertDataFromContextOrState(ctx, d, "ssh.0.cert_data"),
+				},
+			},
+		}
+	} else if certificate.CertType == "https" {
+		r = map[string]interface{}{
+			"https": []map[string]string{
+				{
+					"server_name":  certificate.ServerName,
+					"cert_subtype": certificate.CertSubType,
+					"cert_info":    certificate.CertInfo,
+					"cert_data":    getCertDataFromContextOrState(ctx, d, "https.0.cert_data"),
+				},
+			},
+		}
 	}
+
 	for k, v := range r {
 		if err := persistToState(k, v, d); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+// Since ArgoCD API does not return sensitive data, to avoid data drift :
+// get cert_data from context if it has just been created
+// or from current state if we are in a subsequent "Read"
+func getCertDataFromContextOrState(ctx context.Context, d *schema.ResourceData, statePath string) (certData string) {
+	if v, ok := ctx.Value("cert_data").([]byte); ok {
+		certData = string(v)
+	} else {
+		certData = d.Get(statePath).(string)
+	}
+
+	return
 }

--- a/argocd/structure_repository_certificate.go
+++ b/argocd/structure_repository_certificate.go
@@ -1,0 +1,53 @@
+package argocd
+
+import (
+	"fmt"
+
+	application "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// Expand
+
+func expandRepositoryCertificate(d *schema.ResourceData) (*application.RepositoryCertificate, error) {
+	certificate := &application.RepositoryCertificate{}
+	if v, ok := d.GetOk("server_name"); ok {
+		certificate.ServerName = v.(string)
+	}
+	if v, ok := d.GetOk("cert_type"); ok {
+		certType := v.(string)
+		if certType != "ssh" && certType != "https" {
+			return nil, fmt.Errorf("invalid certificate type '%s': must be either ssh or https", certType)
+		}
+		certificate.CertType = v.(string)
+	}
+	if v, ok := d.GetOk("cert_subtype"); ok {
+		certificate.CertSubType = v.(string)
+	}
+	if v, ok := d.GetOk("cert_data"); ok {
+		certificate.CertData = []byte(v.(string))
+	}
+	if v, ok := d.GetOk("cert_info"); ok {
+		certificate.CertInfo = v.(string)
+	}
+	return certificate, nil
+}
+
+// Flatten
+
+func flattenRepositoryCertificate(certificate *application.RepositoryCertificate, d *schema.ResourceData) error {
+	r := map[string]interface{}{
+		"server_name":  certificate.ServerName,
+		"cert_type":    certificate.CertType,
+		"cert_subtype": certificate.CertSubType,
+		"cert_info":    certificate.CertInfo,
+		// "cert_data": certificate.CertData,  ArgoCD API does not return sensitive data!
+	}
+	for k, v := range r {
+		if err := persistToState(k, v, d); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/argocd/validators.go
+++ b/argocd/validators.go
@@ -2,13 +2,14 @@ package argocd
 
 import (
 	"fmt"
+	"regexp"
+	"strings"
+
 	"github.com/argoproj/pkg/time"
 	"github.com/robfig/cron"
 	"golang.org/x/crypto/ssh"
 	apiValidation "k8s.io/apimachinery/pkg/api/validation"
 	utilValidation "k8s.io/apimachinery/pkg/util/validation"
-	"regexp"
-	"strings"
 )
 
 func validateMetadataLabels(value interface{}, key string) (ws []string, es []error) {
@@ -113,6 +114,14 @@ func validateSSHPrivateKey(value interface{}, key string) (ws []string, es []err
 	v := value.(string)
 	if _, err := ssh.ParsePrivateKey([]byte(v)); err != nil {
 		es = append(es, fmt.Errorf("%s: invalid ssh private key: %s", key, err))
+	}
+	return
+}
+
+func validateCertificateType(value interface{}, key string) (ws []string, es []error) {
+	v := value.(string)
+	if v != "ssh" && v != "https" {
+		es = append(es, fmt.Errorf("%s: kind '%s' mismatch: can only be https or ssh", key, v))
 	}
 	return
 }

--- a/argocd/validators.go
+++ b/argocd/validators.go
@@ -117,11 +117,3 @@ func validateSSHPrivateKey(value interface{}, key string) (ws []string, es []err
 	}
 	return
 }
-
-func validateCertificateType(value interface{}, key string) (ws []string, es []error) {
-	v := value.(string)
-	if v != "ssh" && v != "https" {
-		es = append(es, fmt.Errorf("%s: kind '%s' mismatch: can only be https or ssh", key, v))
-	}
-	return
-}

--- a/docs/resources/repository_certificate.md
+++ b/docs/resources/repository_certificate.md
@@ -1,0 +1,1 @@
+import google.com/ssh-rsa

--- a/docs/resources/repository_certificate.md
+++ b/docs/resources/repository_certificate.md
@@ -1,4 +1,4 @@
-# argocd_certificate
+# argocd_repository_certificate
 
 Creates an ArgoCD certificate, for use with future or existing private repositories.
 
@@ -7,7 +7,7 @@ Creates an ArgoCD certificate, for use with future or existing private repositor
 ### Example ssh certificate
 ```hcl
 // Private repository ssh certificate
-resource "argocd_certificate" "private-git-repository" {
+resource "argocd_repository_certificate" "private-git-repository" {
 	ssh {
 		server_name  = "private-git-repository.local"
 		cert_subtype = "ssh-rsa"
@@ -24,7 +24,7 @@ resource "argocd_repository" "private" {
 
 ### Example https certificate
 ```hcl
-resource "argocd_certificate" "private-git-repository" {
+resource "argocd_repository_certificate" "private-git-repository" {
 	https {
 		server_name  = "private-git-repository.local"
 		cert_data    = <<EOT

--- a/docs/resources/repository_certificate.md
+++ b/docs/resources/repository_certificate.md
@@ -1,1 +1,64 @@
-import google.com/ssh-rsa
+# argocd_certificate
+
+Creates an ArgoCD certificate, for use with future or existing private repositories.
+
+## Example Usage
+
+### Example ssh certificate
+```hcl
+// Private repository ssh certificate
+resource "argocd_certificate" "private-git-repository" {
+	ssh {
+		server_name  = "private-git-repository.local"
+		cert_subtype = "ssh-rsa"
+		cert_data    = <<EOT
+AAAAB3NzaC1yc2EAAAADAQABAAABgQCiPZAufKgxwRgxP9qy2Gtub0FI8qJGtL8Ldb7KatBeRUQQPn8QK7ZYjzYDvP1GOutFMaQT0rKIqaGImIBsztNCno...
+EOT
+	}
+}
+
+resource "argocd_repository" "private" {
+  repo = "git@private-git-repository.local:somerepo.git"
+}
+```
+
+### Example https certificate
+```hcl
+resource "argocd_certificate" "private-git-repository" {
+	https {
+		server_name  = "private-git-repository.local"
+		cert_data    = <<EOT
+-----BEGIN CERTIFICATE-----\nfoo\nbar\n-----END CERTIFICATE-----
+EOT
+	}
+}
+
+resource "argocd_repository" "private" {
+  repo = "https://private-git-repository.local/somerepo.git"
+}
+```
+
+## Argument Reference
+
+* `https` - (Optional), for a https certificate, the nested attributes are documented below.
+* `ssh` - (Optional), for a ssh certificate, the nested attributes are documented below.
+
+### https
+
+* `server_name` - (Required), string, specifies the DNS name of the server this certificate is intended for.
+* `cert_data` - (Required), string, contains the actual certificate data, dependent on the certificate type.
+
+### ssh
+
+* `server_name` - (Required), string, specifies the DNS name of the server this certificate is intended for.
+* `cert_subtype` - (Required), string, specifies the sub type of the cert, i.e. "ssh-rsa".
+* `cert_data` - (Required), string, contains the actual certificate data, dependent on the certificate type.
+
+## Attribute Reference
+
+### https
+* `https.0.cert_subtype` - contains the sub type of the cert, i.e. "ssh-rsa"
+* `https.0.cert_info` - holds additional certificate info (e.g. X509 CommonName, etc).
+
+### ssh
+* `ssh.0.cert_info` - holds additional certificate info (e.g. SSH fingerprint, etc).


### PR DESCRIPTION
Resolves #56 

Implements ssh & https certificates as `argocd_repository_certificate` resource :
* only on server > 1.2.0
* there is no update API, so I didn't make a resourceUpdate
* upstream api has some weird behaviors, so weird workarounds like
https://github.com/MrLuje/terraform-provider-argocd/blob/ee042d95bb4572939961c9b8760fd7d397903e09/argocd/resource_argocd_repository_certificates.go#L124-L132
* not sure why but I had a `create` drift, since the API is not returning the cert_data, it was always reported as an addition
I had no bug with my initial implementation as a flat map but it doesn't work correctly with `ssh`/`https` as a list, so I used context to make it through
https://github.com/MrLuje/terraform-provider-argocd/blob/ee042d95bb4572939961c9b8760fd7d397903e09/argocd/resource_argocd_repository_certificates.go#L144
https://github.com/MrLuje/terraform-provider-argocd/blob/ee042d95bb4572939961c9b8760fd7d397903e09/argocd/structure_repository_certificate.go#L79-L86
* added a resource.RetryContext around `argocd_repository` creation, since certificates can take a bit of time to be fully working (certs are created in a few seconds but the server can take up to ~1min to stop complaining about unknown keys)

TODO
- [X] Add resource.RetryContext on `argocd_repository` update (noticed while writing this PR)
=> Not needed since ArgoCD doesn't revalidate repository connection on update

Examples :
```hcl
// Private repository ssh certificate
resource "argocd_repository_certificate" "private-git-repository" {
	ssh {
		server_name  = "private-git-repository.local"
		cert_subtype = "ssh-rsa"
		cert_data    = <<EOT
AAAAB3NzaC1yc2EAAAADAQABAAABgQCiPZAufKgxwRgxP9qy2Gtub0FI8qJGtL8Ldb7KatBeRUQQPn8QK7ZYjzYDvP1GOutFMaQT0rKIqaGImIBsztNCno...
EOT
	}
}

resource "argocd_repository" "private" {
  repo = "git@private-git-repository.local:somerepo.git"
}
```

### Example https certificate
```hcl
resource "argocd_repository_certificate" "private-git-repository" {
	https {
		server_name  = "private-git-repository.local"
		cert_data    = <<EOT
-----BEGIN CERTIFICATE-----\nfoo\nbar\n-----END CERTIFICATE-----
EOT
	}
}

resource "argocd_repository" "private" {
  repo = "https://private-git-repository.local/somerepo.git"
}
```