### PR TITLE
fix(cluster): crash on empty namespace

### DIFF
--- a/argocd/resource_argocd_cluster_test.go
+++ b/argocd/resource_argocd_cluster_test.go
@@ -356,6 +356,25 @@ func TestAccArgoCDCluster_uniqueByServerTrimmed(t *testing.T) {
 	})
 }
 
+func TestAccArgoCDCluster_namespacesErrorWhenEmpty(t *testing.T) {
+	name := acctest.RandString(10)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckFeatureSupported(t, featureProjectScopedClusters) },
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccArgoCDClusterNamespacesContainsEmptyString(name),
+				ExpectError: regexp.MustCompile("namespaces: must contain non-empty strings"),
+			},
+			{
+				Config:      testAccArgoCDClusterNamespacesContainsEmptyString_MultipleItems(name),
+				ExpectError: regexp.MustCompile("namespaces: must contain non-empty strings"),
+			},
+		},
+	})
+}
+
 func testAccArgoCDClusterBearerToken(clusterName string) string {
 	return fmt.Sprintf(`
 resource "argocd_cluster" "simple" {
@@ -583,6 +602,42 @@ resource "argocd_cluster" "cluster_metadata" {
       test = "annotation"
     }
   }
+  config {
+    # Uses Kind's bootstrap token whose ttl is 24 hours after cluster bootstrap.
+    bearer_token = "abcdef.0123456789abcdef"
+    tls_client_config {
+      insecure = true
+    }
+  }
+}
+`, clusterName)
+}
+
+func testAccArgoCDClusterNamespacesContainsEmptyString(clusterName string) string {
+	return fmt.Sprintf(`
+resource "argocd_cluster" "simple" {
+  server = "https://kubernetes.default.svc.cluster.local"
+  name   = "%s"
+  shard  = "1"
+  namespaces = [""]
+  config {
+    # Uses Kind's bootstrap token whose ttl is 24 hours after cluster bootstrap.
+    bearer_token = "abcdef.0123456789abcdef"
+    tls_client_config {
+      insecure = true
+    }
+  }
+}
+`, clusterName)
+}
+
+func testAccArgoCDClusterNamespacesContainsEmptyString_MultipleItems(clusterName string) string {
+	return fmt.Sprintf(`
+resource "argocd_cluster" "simple" {
+  server = "https://kubernetes.default.svc.cluster.local"
+  name   = "%s"
+  shard  = "1"
+  namespaces = ["default", ""]
   config {
     # Uses Kind's bootstrap token whose ttl is 24 hours after cluster bootstrap.
     bearer_token = "abcdef.0123456789abcdef"

--- a/argocd/structure_cluster.go
+++ b/argocd/structure_cluster.go
@@ -1,6 +1,8 @@
 package argocd
 
 import (
+	"fmt"
+
 	application "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -24,6 +26,9 @@ func expandCluster(d *schema.ResourceData) (*application.Cluster, error) {
 	}
 	if ns, ok := d.GetOk("namespaces"); ok {
 		for _, n := range ns.([]interface{}) {
+			if n == nil {
+				return nil, fmt.Errorf("namespaces: must contain non-empty strings")
+			}
 			cluster.Namespaces = append(cluster.Namespaces, n.(string))
 		}
 	}


### PR DESCRIPTION
Fix a crash when `cluster.namespaces` contains empty string

```hcl
resource "argocd_cluster" "simple" {
  server = "https://kubernetes.default.svc.cluster.local"
  name   = "%s"
  shard  = "1"
  namespaces = [""]
  config {
    # Uses Kind's bootstrap token whose ttl is 24 hours after cluster bootstrap.
    bearer_token = "abcdef.0123456789abcdef"
    tls_client_config {
      insecure = true
    }
  }
}
```

Documentation for namespaces is : 

> Holds list of namespaces which are accessible in that cluster. Cluster level resources will be ignored if namespace list is not empty.

So, nil item in `namespaces` makes no sense

Resolves #197 