### PR TITLE
load kubernetes config file from "kube_config"

### DIFF
--- a/argocd/provider.go
+++ b/argocd/provider.go
@@ -261,13 +261,11 @@ func initApiClient(d *schema.ResourceData) (
 
 			if v, ok := k8sGetOk(d, "config_context"); ok {
 				contextName := v.(string)
-				_, ok = rawConfig.Contexts[contextName]
-				if !ok {
+
+				if _, ok := rawConfig.Contexts[v.(string)]; !ok {
 					return nil, errors.New(fmt.Sprintf("config_context %s not found", contextName))
-				}
-			} else {
-				if _, ok = rawConfig.Contexts[rawConfig.CurrentContext]; !ok {
-					return nil, errors.New("kube config has no current context")
+				} else {
+					opts.KubeOverrides.CurrentContext = contextName
 				}
 			}
 		}


### PR DESCRIPTION
I guess https://github.com/oboukili/terraform-provider-argocd/pull/100 exposed `kubernetes.config_path` argument in argocd `provider` that is not used anywhere. I am working on a PR to fix this.

So this is a hack but it works 😆 

related:
https://github.com/argoproj/argo-cd/issues/5905