### PR TITLE
Readme fix: badge update and kustomize is needed to run tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Terraform Provider for ArgoCD
 
-![Acceptance Tests](https://github.com/oboukili/terraform-provider-argocd/workflows/Acceptance%20Tests/badge.svg)
+[![Tests](https://github.com/oboukili/terraform-provider-argocd/actions/workflows/tests.yml/badge.svg)](https://github.com/oboukili/terraform-provider-argocd/actions/workflows/tests.yml)
 
 ---
 
@@ -351,7 +351,7 @@ go build
 
 ### Running tests
 
-The acceptance tests run against a disposable ArgoCD installation within a [Kind](https://github.com/kubernetes-sigs/kind) cluster. You will only need to have a running Docker daemon running as an additional prerequisite.
+The acceptance tests run against a disposable ArgoCD installation within a [Kind](https://github.com/kubernetes-sigs/kind) cluster. Other requirements are having a Docker daemon running and [Kustomize](https://kubectl.docs.kubernetes.io/installation/kustomize/) installed.
 
 ```sh
 make testacc_prepare_env


### PR DESCRIPTION
I was wanting to contribute.

While following the readme to run the tests, I noticed that the tests fail because I didn't not have Kustomize installed. I've updated the README accordingly on this PR.

Another issue I found, while combing the readme, was that the status badge wasn't working. I think I fixed it to what it is meant to show.