### PR TITLE
Get tests working on M1/ARM 64

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -209,6 +209,8 @@ replace (
 	github.com/grpc-ecosystem/grpc-gateway => github.com/grpc-ecosystem/grpc-gateway v1.16.0
 	github.com/improbable-eng/grpc-web => github.com/improbable-eng/grpc-web v0.0.0-20181111100011-16092bd1d58a
 
+	github.com/remyoudompheng/bigfft => github.com/remyoudompheng/bigfft v0.0.0-20220927061507-ef77025ab5aa
+
 	// Avoid CVE-2022-28948
 	gopkg.in/yaml.v3 => gopkg.in/yaml.v3 v3.0.1
 

--- a/go.sum
+++ b/go.sum
@@ -853,8 +853,8 @@ github.com/quobyte/api v0.1.8/go.mod h1:jL7lIHrmqQ7yh05OJ+eEEdHr0u/kmT1Ff9iHd+4H
 github.com/r3labs/diff v1.1.0 h1:V53xhrbTHrWFWq3gI4b94AjgEJOerO1+1l0xyHOBi8M=
 github.com/r3labs/diff v1.1.0/go.mod h1:7WjXasNzi0vJetRcB/RqNl5dlIsmXcTTLmF5IoH6Xig=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
-github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446 h1:/NRJ5vAYoqz+7sG51ubIDHXeWO8DlTSrToPu6q11ziA=
-github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446/go.mod h1:uYEyJGbgTkfkS4+E/PavXkNJcbFIpEtjt2B0KDQ5+9M=
+github.com/remyoudompheng/bigfft v0.0.0-20220927061507-ef77025ab5aa h1:tEkEyxYeZ43TR55QU/hsIt9aRGBxbgGuz9CGykjvogY=
+github.com/remyoudompheng/bigfft v0.0.0-20220927061507-ef77025ab5aa/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/robfig/cron v1.2.0 h1:ZjScXvvxeQ63Dbyxy76Fj3AT3Ut0aKsyd2/tl3DTMuQ=
 github.com/robfig/cron v1.2.0/go.mod h1:JGuDeoQd7Z6yL4zQhZ3OPEVHB7fL6Ka6skscFHfmt2k=
 github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=


### PR DESCRIPTION
When I was trying to run the tests locally, they were failing to compile on master. Why? I am on a Mac M1 / Arm64 computer. One of the transitive dependencies, bigftt, [is five years old](https://github.com/remyoudompheng/bigfft/tree/52369c62f4463a21c8ff8531194c5526322b8521) and lacks arm64 support. Using a replace to get a newer version does allow me to run the tests.

If you are curious about the error:

```
make testacc_prepare_env && make testacc && make testacc_clean_env
....                                               
sh scripts/testacc.sh
# github.com/remyoudompheng/bigfft
../../../../pkg/mod/github.com/remyoudompheng/bigfft@v0.0.0-20170806203942-52369c62f446/arith_decl.go:10:6: missing function body
../../../../pkg/mod/github.com/remyoudompheng/bigfft@v0.0.0-20170806203942-52369c62f446/arith_decl.go:11:6: missing function body
../../../../pkg/mod/github.com/remyoudompheng/bigfft@v0.0.0-20170806203942-52369c62f446/arith_decl.go:12:6: missing function body
../../../../pkg/mod/github.com/remyoudompheng/bigfft@v0.0.0-20170806203942-52369c62f446/arith_decl.go:13:6: missing function body
../../../../pkg/mod/github.com/remyoudompheng/bigfft@v0.0.0-20170806203942-52369c62f446/arith_decl.go:14:6: missing function body
../../../../pkg/mod/github.com/remyoudompheng/bigfft@v0.0.0-20170806203942-52369c62f446/arith_decl.go:15:6: missing function body
../../../../pkg/mod/github.com/remyoudompheng/bigfft@v0.0.0-20170806203942-52369c62f446/arith_decl.go:16:6: missing function body
../../../../pkg/mod/github.com/remyoudompheng/bigfft@v0.0.0-20170806203942-52369c62f446/arith_decl.go:17:6: missing function body
../../../../pkg/mod/github.com/remyoudompheng/bigfft@v0.0.0-20170806203942-52369c62f446/arith_decl.go:18:6: missing function body
../../../../pkg/mod/github.com/remyoudompheng/bigfft@v0.0.0-20170806203942-52369c62f446/arith_decl.go:19:6: missing function body
../../../../pkg/mod/github.com/remyoudompheng/bigfft@v0.0.0-20170806203942-52369c62f446/arith_decl.go:19:6: too many errors
?       github.com/oboukili/terraform-provider-argocd   [no test files]
FAIL    github.com/oboukili/terraform-provider-argocd/argocd [build failed]
FAIL
make: *** [testacc] Error 2
kind delete cluster --name argocd
Deleting cluster "argocd" ...
```