### PR TITLE
Add support for GitHub app credentials

### DIFF
--- a/argocd/resource_argocd_repository.go
+++ b/argocd/resource_argocd_repository.go
@@ -40,6 +40,15 @@ func resourceArgoCDRepositoryCreate(ctx context.Context, d *schema.ResourceData,
 
 	c := *server.RepositoryClient
 	repo, err := expandRepository(d)
+	if err != nil {
+		return []diag.Diagnostic{
+			{
+				Severity: diag.Error,
+				Summary:  fmt.Sprintf("could not expand repository attributes: %s", err),
+				Detail:   err.Error(),
+			},
+		}
+	}
 
 	featureProjectScopedRepositoriesSupported, err := server.isFeatureSupported(featureProjectScopedRepositories)
 	if err != nil {
@@ -212,6 +221,15 @@ func resourceArgoCDRepositoryUpdate(ctx context.Context, d *schema.ResourceData,
 	}
 	c := *server.RepositoryClient
 	repo, err := expandRepository(d)
+	if err != nil {
+		return []diag.Diagnostic{
+			{
+				Severity: diag.Error,
+				Summary:  fmt.Sprintf("could not expand repository attributes: %s", err),
+				Detail:   err.Error(),
+			},
+		}
+	}
 
 	featureProjectScopedRepositoriesSupported, err := server.isFeatureSupported(featureProjectScopedRepositories)
 	if err != nil {

--- a/argocd/resource_argocd_repository.go
+++ b/argocd/resource_argocd_repository.go
@@ -39,7 +39,7 @@ func resourceArgoCDRepositoryCreate(ctx context.Context, d *schema.ResourceData,
 	}
 
 	c := *server.RepositoryClient
-	repo := expandRepository(d)
+	repo, err := expandRepository(d)
 
 	featureProjectScopedRepositoriesSupported, err := server.isFeatureSupported(featureProjectScopedRepositories)
 	if err != nil {
@@ -211,7 +211,7 @@ func resourceArgoCDRepositoryUpdate(ctx context.Context, d *schema.ResourceData,
 		}
 	}
 	c := *server.RepositoryClient
-	repo := expandRepository(d)
+	repo, err := expandRepository(d)
 
 	featureProjectScopedRepositoriesSupported, err := server.isFeatureSupported(featureProjectScopedRepositories)
 	if err != nil {

--- a/argocd/resource_argocd_repository_credentials.go
+++ b/argocd/resource_argocd_repository_credentials.go
@@ -136,7 +136,7 @@ func resourceArgoCDRepositoryCredentialsUpdate(ctx context.Context, d *schema.Re
 		return []diag.Diagnostic{
 			{
 				Severity: diag.Error,
-				Summary:  fmt.Sprintf("could not expand repository attributes: %s", err),
+				Summary:  fmt.Sprintf("could not expand repository credential attributes: %s", err),
 				Detail:   err.Error(),
 			},
 		}

--- a/argocd/resource_argocd_repository_credentials.go
+++ b/argocd/resource_argocd_repository_credentials.go
@@ -37,6 +37,15 @@ func resourceArgoCDRepositoryCredentialsCreate(ctx context.Context, d *schema.Re
 	}
 	c := *server.RepoCredsClient
 	repoCreds, err := expandRepositoryCredentials(d)
+	if err != nil {
+		return []diag.Diagnostic{
+			{
+				Severity: diag.Error,
+				Summary:  fmt.Sprintf("could not expand repository credential attributes: %s", err),
+				Detail:   err.Error(),
+			},
+		}
+	}
 
 	tokenMutexConfiguration.Lock()
 	rc, err := c.CreateRepositoryCredentials(
@@ -123,6 +132,15 @@ func resourceArgoCDRepositoryCredentialsUpdate(ctx context.Context, d *schema.Re
 	}
 	c := *server.RepoCredsClient
 	repoCreds, err := expandRepositoryCredentials(d)
+	if err != nil {
+		return []diag.Diagnostic{
+			{
+				Severity: diag.Error,
+				Summary:  fmt.Sprintf("could not expand repository attributes: %s", err),
+				Detail:   err.Error(),
+			},
+		}
+	}
 
 	tokenMutexConfiguration.Lock()
 	r, err := c.UpdateRepositoryCredentials(

--- a/argocd/resource_argocd_repository_credentials.go
+++ b/argocd/resource_argocd_repository_credentials.go
@@ -36,7 +36,7 @@ func resourceArgoCDRepositoryCredentialsCreate(ctx context.Context, d *schema.Re
 		}
 	}
 	c := *server.RepoCredsClient
-	repoCreds := expandRepositoryCredentials(d)
+	repoCreds, err := expandRepositoryCredentials(d)
 
 	tokenMutexConfiguration.Lock()
 	rc, err := c.CreateRepositoryCredentials(
@@ -122,7 +122,7 @@ func resourceArgoCDRepositoryCredentialsUpdate(ctx context.Context, d *schema.Re
 		}
 	}
 	c := *server.RepoCredsClient
-	repoCreds := expandRepositoryCredentials(d)
+	repoCreds, err := expandRepositoryCredentials(d)
 
 	tokenMutexConfiguration.Lock()
 	r, err := c.UpdateRepositoryCredentials(

--- a/argocd/resource_argocd_repository_credentials_test.go
+++ b/argocd/resource_argocd_repository_credentials_test.go
@@ -52,7 +52,7 @@ func TestAccArgoCDRepositoryCredentials(t *testing.T) {
 					"https://private-git-repository.argocd.svc.cluster.local/project-1.git",
 					"123456",
 					"987654321",
-					"github.some.company.com",
+					"testing",
 					sshPrivateKey,
 				),
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -69,7 +69,7 @@ func TestAccArgoCDRepositoryCredentials(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"argocd_repository_credentials.githubapp",
 						"githubapp_enterprise_base_url",
-						"github.some.company.com",
+						"testing",
 					),
 				),
 			},

--- a/argocd/resource_argocd_repository_credentials_test.go
+++ b/argocd/resource_argocd_repository_credentials_test.go
@@ -47,6 +47,20 @@ func TestAccArgoCDRepositoryCredentials(t *testing.T) {
 					10,
 				),
 			},
+			{
+				Config: testAccArgoCDRepositoryCredentialsGitHubApp(
+					"https://private-git-repository.argocd.svc.cluster.local/project-1.git",
+					"123456",
+					"987654321",
+					"some.company.github.com",
+					sshPrivateKey,
+				),
+				Check: resource.TestCheckResourceAttr(
+					"argocd_repository_credentials.githubapp",
+					"githubapp_id",
+					"123456",
+				),
+			},
 		},
 	})
 }
@@ -78,6 +92,20 @@ resource "argocd_repository_credentials" "private" {
   ssh_private_key = "-----BEGIN OPENSSH PRIVATE KEY-----\nb3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW\nQyNTUxOQAAACCGe6Vx0gbKqKCI0wIplfgK5JBjCDO3bhtU3sZfLoeUZgAAAJB9cNEifXDR\nIgAAAAtzc2gtZWQyNTUxOQAAACCGe6Vx0gbKqKCI0wIplfgK5JBjCDO3bhtU3sZfLoeUZg\nAAAEAJeUrObjoTbGO1Sq4TXHl/j4RJ5aKMC1OemWuHmLK7XYZ7pXHSBsqooIjTAimV+Ark\nkGMIM7duG1Texl8uh5RmAAAAC3Rlc3RAYXJnb2NkAQI=\n-----END OPENSSH PRIVATE KEY-----"
 }
 `)
+}
+
+func testAccArgoCDRepositoryCredentialsGitHubApp(repoUrl, githubAppId, githubAppInstallId, githubAppUrl, githubAppKey string) string {
+	return fmt.Sprintf(`
+resource "argocd_repository_credentials" "githubapp" {
+  url             = "%s"
+  githubapp_id    = "%s"
+  githubapp_installation_id = "%s"
+  githubapp_enterprise_base_url = "%s"
+  githubapp_private_key = <<EOT
+%s
+EOT
+}
+`, repoUrl, githubAppId, githubAppInstallId, githubAppUrl, githubAppKey)
 }
 
 func generateSSHPrivateKey() (privateKey string, err error) {

--- a/argocd/resource_argocd_repository_credentials_test.go
+++ b/argocd/resource_argocd_repository_credentials_test.go
@@ -49,16 +49,28 @@ func TestAccArgoCDRepositoryCredentials(t *testing.T) {
 			},
 			{
 				Config: testAccArgoCDRepositoryCredentialsGitHubApp(
-					"https://private-git-repository.argocd.svc.cluster.local/project-1.git",
+					"git@private-git-repository.argocd.svc.cluster.local",
 					"123456",
 					"987654321",
-					"some.company.github.com",
+					"github.some.company.com",
 					sshPrivateKey,
 				),
-				Check: resource.TestCheckResourceAttr(
-					"argocd_repository_credentials.githubapp",
-					"githubapp_id",
-					"123456",
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"argocd_repository_credentials.githubapp",
+						"githubapp_id",
+						"123456",
+					),
+					resource.TestCheckResourceAttr(
+						"argocd_repository_credentials.githubapp",
+						"githubapp_installation_id",
+						"987654321",
+					),
+					resource.TestCheckResourceAttr(
+						"argocd_repository_credentials.githubapp",
+						"githubapp_enterprise_base_url",
+						"github.some.company.com",
+					),
 				),
 			},
 		},
@@ -97,11 +109,11 @@ resource "argocd_repository_credentials" "private" {
 func testAccArgoCDRepositoryCredentialsGitHubApp(repoUrl, githubAppId, githubAppInstallId, githubAppUrl, githubAppKey string) string {
 	return fmt.Sprintf(`
 resource "argocd_repository_credentials" "githubapp" {
-  url             = "%s"
-  githubapp_id    = "%s"
-  githubapp_installation_id = "%s"
+  url             				= "%s"
+  githubapp_id    				= "%s"
+  githubapp_installation_id 	= "%s"
   githubapp_enterprise_base_url = "%s"
-  githubapp_private_key = <<EOT
+  githubapp_private_key 		= <<EOT
 %s
 EOT
 }

--- a/argocd/resource_argocd_repository_credentials_test.go
+++ b/argocd/resource_argocd_repository_credentials_test.go
@@ -47,12 +47,24 @@ func TestAccArgoCDRepositoryCredentials(t *testing.T) {
 					10,
 				),
 			},
+		},
+	})
+}
+
+func TestAccArgoCDRepositoryCredentials_GitHubApp(t *testing.T) {
+	sshPrivateKey, err := generateSSHPrivateKey()
+	assert.NoError(t, err)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
 			{
 				Config: testAccArgoCDRepositoryCredentialsGitHubApp(
 					"https://private-git-repository.argocd.svc.cluster.local/project-1.git",
 					"123456",
 					"987654321",
-					"testing",
+					"https://ghe.example.com/api/v3",
 					sshPrivateKey,
 				),
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -69,7 +81,7 @@ func TestAccArgoCDRepositoryCredentials(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"argocd_repository_credentials.githubapp",
 						"githubapp_enterprise_base_url",
-						"testing",
+						"https://ghe.example.com/api/v3",
 					),
 				),
 			},
@@ -106,7 +118,7 @@ resource "argocd_repository_credentials" "private" {
 `)
 }
 
-func testAccArgoCDRepositoryCredentialsGitHubApp(repoUrl, githubAppId, githubAppInstallId, githubAppUrl, githubAppKey string) string {
+func testAccArgoCDRepositoryCredentialsGitHubApp(repoUrl, id, installID, enterpriseBaseURL, appKey string) string {
 	return fmt.Sprintf(`
 resource "argocd_repository_credentials" "githubapp" {
   url             				= "%s"
@@ -117,7 +129,7 @@ resource "argocd_repository_credentials" "githubapp" {
 %s
 EOT
 }
-`, repoUrl, githubAppId, githubAppInstallId, githubAppUrl, githubAppKey)
+`, repoUrl, id, installID, enterpriseBaseURL, appKey)
 }
 
 func generateSSHPrivateKey() (privateKey string, err error) {

--- a/argocd/resource_argocd_repository_credentials_test.go
+++ b/argocd/resource_argocd_repository_credentials_test.go
@@ -49,7 +49,7 @@ func TestAccArgoCDRepositoryCredentials(t *testing.T) {
 			},
 			{
 				Config: testAccArgoCDRepositoryCredentialsGitHubApp(
-					"git@private-git-repository.argocd.svc.cluster.local",
+					"https://private-git-repository.argocd.svc.cluster.local/project-1.git",
 					"123456",
 					"987654321",
 					"github.some.company.com",

--- a/argocd/schema_repository.go
+++ b/argocd/schema_repository.go
@@ -93,14 +93,16 @@ func repositorySchema() map[string]*schema.Schema {
 			Computed: true,
 		},
 		"githubapp_id": {
-			Type:        schema.TypeString,
-			Description: "GitHub App id for authenticating at the repo server only for GitHub repos",
-			Optional:    true,
+			Type:         schema.TypeString,
+			Description:  "GitHub App id for authenticating at the repo server only for GitHub repos",
+			ValidateFunc: validatePositiveInteger,
+			Optional:     true,
 		},
 		"githubapp_installation_id": {
-			Type:        schema.TypeString,
-			Description: "GitHub App installation id for authenticating at the repo server only for GitHub repos",
-			Optional:    true,
+			Type:         schema.TypeString,
+			Description:  "GitHub App installation id for authenticating at the repo server only for GitHub repos",
+			ValidateFunc: validatePositiveInteger,
+			Optional:     true,
 		},
 		"githubapp_enterprise_base_url": {
 			Type:        schema.TypeString,

--- a/argocd/schema_repository.go
+++ b/argocd/schema_repository.go
@@ -92,5 +92,27 @@ func repositorySchema() map[string]*schema.Schema {
 			Type:     schema.TypeString,
 			Computed: true,
 		},
+		"githubapp_id": {
+			Type:        schema.TypeString,
+			Description: "GitHub App id for authenticating at the repo server only for GitHub repos",
+			Optional:    true,
+		},
+		"githubapp_installation_id": {
+			Type:        schema.TypeString,
+			Description: "GitHub App installation id for authenticating at the repo server only for GitHub repos",
+			Optional:    true,
+		},
+		"githubapp_enterprise_base_url": {
+			Type:        schema.TypeString,
+			Description: "If using GitHub App for a GitHub Enterprise repository the host url is required",
+			Optional:    true,
+		},
+		"githubapp_private_key": {
+			Type:         schema.TypeString,
+			Sensitive:    true,
+			Description:  "Private key data (pem) of GitHub App for authenticating at the repo server only for GitHub repos",
+			ValidateFunc: validateSSHPrivateKey,
+			Optional:     true,
+		},
 	}
 }

--- a/argocd/schema_repository_credentials.go
+++ b/argocd/schema_repository_credentials.go
@@ -47,5 +47,27 @@ func repositoryCredentialsSchema() map[string]*schema.Schema {
 			Description: "Specify whether the repo server should be viewed as OCI compliant",
 			Optional:    true,
 		},
+		"githubApp_id": {
+			Type:        schema.TypeInt,
+			Description: "GitHub App id for authenticating at the repo server only for GitHub repos",
+			Optional:    true,
+		},
+		"githubApp_installation_id": {
+			Type:        schema.TypeInt,
+			Description: "GitHub App installation id for authenticating at the repo server only for GitHub repos",
+			Optional:    true,
+		},
+		"githubApp_enterprise_base_url": {
+			Type:        schema.TypeString,
+			Description: "If using GitHub App for a GitHub Enterprise repository the host url is required",
+			Optional:    true,
+		},
+		"githubApp_private_key": {
+			Type:         schema.TypeString,
+			Sensitive:    true,
+			Description:  "Private key data (pem) of GitHub App for authenticating at the repo server only for GitHub repos",
+			ValidateFunc: validateSSHPrivateKey,
+			Optional:     true,
+		},
 	}
 }

--- a/argocd/schema_repository_credentials.go
+++ b/argocd/schema_repository_credentials.go
@@ -48,12 +48,12 @@ func repositoryCredentialsSchema() map[string]*schema.Schema {
 			Optional:    true,
 		},
 		"githubapp_id": {
-			Type:        schema.TypeInt,
+			Type:        schema.TypeString,
 			Description: "GitHub App id for authenticating at the repo server only for GitHub repos",
 			Optional:    true,
 		},
 		"githubapp_installation_id": {
-			Type:        schema.TypeInt,
+			Type:        schema.TypeString,
 			Description: "GitHub App installation id for authenticating at the repo server only for GitHub repos",
 			Optional:    true,
 		},

--- a/argocd/schema_repository_credentials.go
+++ b/argocd/schema_repository_credentials.go
@@ -48,14 +48,16 @@ func repositoryCredentialsSchema() map[string]*schema.Schema {
 			Optional:    true,
 		},
 		"githubapp_id": {
-			Type:        schema.TypeString,
-			Description: "GitHub App id for authenticating at the repo server only for GitHub repos",
-			Optional:    true,
+			Type:         schema.TypeString,
+			Description:  "GitHub App id for authenticating at the repo server only for GitHub repos",
+			ValidateFunc: validatePositiveInteger,
+			Optional:     true,
 		},
 		"githubapp_installation_id": {
-			Type:        schema.TypeString,
-			Description: "GitHub App installation id for authenticating at the repo server only for GitHub repos",
-			Optional:    true,
+			Type:         schema.TypeString,
+			Description:  "GitHub App installation id for authenticating at the repo server only for GitHub repos",
+			ValidateFunc: validatePositiveInteger,
+			Optional:     true,
 		},
 		"githubapp_enterprise_base_url": {
 			Type:        schema.TypeString,

--- a/argocd/schema_repository_credentials.go
+++ b/argocd/schema_repository_credentials.go
@@ -47,22 +47,22 @@ func repositoryCredentialsSchema() map[string]*schema.Schema {
 			Description: "Specify whether the repo server should be viewed as OCI compliant",
 			Optional:    true,
 		},
-		"githubApp_id": {
+		"githubapp_id": {
 			Type:        schema.TypeInt,
 			Description: "GitHub App id for authenticating at the repo server only for GitHub repos",
 			Optional:    true,
 		},
-		"githubApp_installation_id": {
+		"githubapp_installation_id": {
 			Type:        schema.TypeInt,
 			Description: "GitHub App installation id for authenticating at the repo server only for GitHub repos",
 			Optional:    true,
 		},
-		"githubApp_enterprise_base_url": {
+		"githubapp_enterprise_base_url": {
 			Type:        schema.TypeString,
 			Description: "If using GitHub App for a GitHub Enterprise repository the host url is required",
 			Optional:    true,
 		},
-		"githubApp_private_key": {
+		"githubapp_private_key": {
 			Type:         schema.TypeString,
 			Sensitive:    true,
 			Description:  "Private key data (pem) of GitHub App for authenticating at the repo server only for GitHub repos",

--- a/argocd/structure_repository.go
+++ b/argocd/structure_repository.go
@@ -93,10 +93,10 @@ func flattenRepository(repository *application.Repository, d *schema.ResourceDat
 		"type":                          repository.Type,
 		"githubapp_enterprise_base_url": repository.GitHubAppEnterpriseBaseURL,
 	}
-	for repository.GithubAppId > 0 {
+	if repository.GithubAppId > 0 {
 		r["githubapp_id"] = convertInt64ToString(repository.GithubAppId)
 	}
-	for repository.GithubAppInstallationId > 0 {
+	if repository.GithubAppInstallationId > 0 {
 		r["githubapp_installation_id"] = convertInt64ToString(repository.GithubAppInstallationId)
 	}
 	for k, v := range r {

--- a/argocd/structure_repository.go
+++ b/argocd/structure_repository.go
@@ -49,6 +49,18 @@ func expandRepository(d *schema.ResourceData) *application.Repository {
 	if v, ok := d.GetOk("type"); ok {
 		repository.Type = v.(string)
 	}
+	if v, ok := d.GetOk("githubApp_id"); ok {
+		repository.GithubAppId = v.(int64)
+	}
+	if v, ok := d.GetOk("githubApp_installation_id"); ok {
+		repository.GithubAppInstallationId = v.(int64)
+	}
+	if v, ok := d.GetOk("githubApp_enterprise_base_url"); ok {
+		repository.GitHubAppEnterpriseBaseURL = v.(string)
+	}
+	if v, ok := d.GetOk("githubApp_private_key"); ok {
+		repository.GithubAppPrivateKey = v.(string)
+	}
 	return repository
 }
 
@@ -56,21 +68,24 @@ func expandRepository(d *schema.ResourceData) *application.Repository {
 
 func flattenRepository(repository *application.Repository, d *schema.ResourceData) error {
 	r := map[string]interface{}{
-		"repo":                    repository.Repo,
-		"connection_state_status": repository.ConnectionState.Status,
-		"enable_lfs":              repository.EnableLFS,
-		"inherited_creds":         repository.InheritedCreds,
-		"insecure":                repository.Insecure,
-		"name":                    repository.Name,
-		"project":                 repository.Project,
+		"repo":                    			repository.Repo,
+		"connection_state_status": 			repository.ConnectionState.Status,
+		"enable_lfs":              			repository.EnableLFS,
+		"inherited_creds":         			repository.InheritedCreds,
+		"insecure":                			repository.Insecure,
+		"name":                    			repository.Name,
+		"project":                 			repository.Project,
 		// TODO: in case of repositoryCredentials existence, will perma-diff
-		//"username":                repository.Username,
+		//"username":                		repository.Username,
 		// TODO: ArgoCD API does not return sensitive data!
-		//"password":                repository.Password,
-		//"ssh_private_key":         repository.SSHPrivateKey,
-		//"tls_client_cert_key":     repository.TLSClientCertKey,
-		"tls_client_cert_data": repository.TLSClientCertData,
-		"type":                 repository.Type,
+		//"password":                		repository.Password,
+		//"ssh_private_key":         		repository.SSHPrivateKey,
+		//"tls_client_cert_key":     		repository.TLSClientCertKey,
+		"tls_client_cert_data": 			repository.TLSClientCertData,
+		"type":                 			repository.Type,
+		"githubApp_id": 					repository.GithubAppId,
+		"githubApp_installation_id":		repository.GithubAppInstallationId,
+		"githubApp_enterprise_base_url": 	repository.GitHubAppEnterpriseBaseURL,
 	}
 	for k, v := range r {
 		if err := persistToState(k, v, d); err != nil {

--- a/argocd/structure_repository.go
+++ b/argocd/structure_repository.go
@@ -69,7 +69,7 @@ func expandRepository(d *schema.ResourceData) (*application.Repository, error) {
 	if v, ok := d.GetOk("githubapp_private_key"); ok {
 		repository.GithubAppPrivateKey = v.(string)
 	}
-	return repository, err
+	return repository, nil
 }
 
 // Flatten

--- a/argocd/structure_repository.go
+++ b/argocd/structure_repository.go
@@ -91,9 +91,13 @@ func flattenRepository(repository *application.Repository, d *schema.ResourceDat
 		//"tls_client_cert_key":     		repository.TLSClientCertKey,
 		"tls_client_cert_data":          repository.TLSClientCertData,
 		"type":                          repository.Type,
-		"githubapp_id":                  convertInt64ToString(repository.GithubAppId),
-		"githubapp_installation_id":     convertInt64ToString(repository.GithubAppInstallationId),
 		"githubapp_enterprise_base_url": repository.GitHubAppEnterpriseBaseURL,
+	}
+	for repository.GithubAppId > 0 {
+		r["githubapp_id"] = convertInt64ToString(repository.GithubAppId)
+	}
+	for repository.GithubAppInstallationId > 0 {
+		r["githubapp_installation_id"] = convertInt64ToString(repository.GithubAppInstallationId)
 	}
 	for k, v := range r {
 		if err := persistToState(k, v, d); err != nil {

--- a/argocd/structure_repository.go
+++ b/argocd/structure_repository.go
@@ -68,24 +68,24 @@ func expandRepository(d *schema.ResourceData) *application.Repository {
 
 func flattenRepository(repository *application.Repository, d *schema.ResourceData) error {
 	r := map[string]interface{}{
-		"repo":                    			repository.Repo,
-		"connection_state_status": 			repository.ConnectionState.Status,
-		"enable_lfs":              			repository.EnableLFS,
-		"inherited_creds":         			repository.InheritedCreds,
-		"insecure":                			repository.Insecure,
-		"name":                    			repository.Name,
-		"project":                 			repository.Project,
+		"repo":                    repository.Repo,
+		"connection_state_status": repository.ConnectionState.Status,
+		"enable_lfs":              repository.EnableLFS,
+		"inherited_creds":         repository.InheritedCreds,
+		"insecure":                repository.Insecure,
+		"name":                    repository.Name,
+		"project":                 repository.Project,
 		// TODO: in case of repositoryCredentials existence, will perma-diff
 		//"username":                		repository.Username,
 		// TODO: ArgoCD API does not return sensitive data!
 		//"password":                		repository.Password,
 		//"ssh_private_key":         		repository.SSHPrivateKey,
 		//"tls_client_cert_key":     		repository.TLSClientCertKey,
-		"tls_client_cert_data": 			repository.TLSClientCertData,
-		"type":                 			repository.Type,
-		"githubApp_id": 					repository.GithubAppId,
-		"githubApp_installation_id":		repository.GithubAppInstallationId,
-		"githubApp_enterprise_base_url": 	repository.GitHubAppEnterpriseBaseURL,
+		"tls_client_cert_data":          repository.TLSClientCertData,
+		"type":                          repository.Type,
+		"githubApp_id":                  repository.GithubAppId,
+		"githubApp_installation_id":     repository.GithubAppInstallationId,
+		"githubApp_enterprise_base_url": repository.GitHubAppEnterpriseBaseURL,
 	}
 	for k, v := range r {
 		if err := persistToState(k, v, d); err != nil {

--- a/argocd/structure_repository.go
+++ b/argocd/structure_repository.go
@@ -49,16 +49,16 @@ func expandRepository(d *schema.ResourceData) *application.Repository {
 	if v, ok := d.GetOk("type"); ok {
 		repository.Type = v.(string)
 	}
-	if v, ok := d.GetOk("githubApp_id"); ok {
+	if v, ok := d.GetOk("githubapp_id"); ok {
 		repository.GithubAppId = v.(int64)
 	}
-	if v, ok := d.GetOk("githubApp_installation_id"); ok {
+	if v, ok := d.GetOk("githubapp_installation_id"); ok {
 		repository.GithubAppInstallationId = v.(int64)
 	}
-	if v, ok := d.GetOk("githubApp_enterprise_base_url"); ok {
+	if v, ok := d.GetOk("githubapp_enterprise_base_url"); ok {
 		repository.GitHubAppEnterpriseBaseURL = v.(string)
 	}
-	if v, ok := d.GetOk("githubApp_private_key"); ok {
+	if v, ok := d.GetOk("githubapp_private_key"); ok {
 		repository.GithubAppPrivateKey = v.(string)
 	}
 	return repository
@@ -83,9 +83,9 @@ func flattenRepository(repository *application.Repository, d *schema.ResourceDat
 		//"tls_client_cert_key":     		repository.TLSClientCertKey,
 		"tls_client_cert_data":          repository.TLSClientCertData,
 		"type":                          repository.Type,
-		"githubApp_id":                  repository.GithubAppId,
-		"githubApp_installation_id":     repository.GithubAppInstallationId,
-		"githubApp_enterprise_base_url": repository.GitHubAppEnterpriseBaseURL,
+		"githubapp_id":                  repository.GithubAppId,
+		"githubapp_installation_id":     repository.GithubAppInstallationId,
+		"githubapp_enterprise_base_url": repository.GitHubAppEnterpriseBaseURL,
 	}
 	for k, v := range r {
 		if err := persistToState(k, v, d); err != nil {

--- a/argocd/structure_repository.go
+++ b/argocd/structure_repository.go
@@ -8,7 +8,9 @@ import (
 
 // Expand
 
-func expandRepository(d *schema.ResourceData) *application.Repository {
+func expandRepository(d *schema.ResourceData) (*application.Repository, error) {
+	var err error
+
 	repository := &application.Repository{}
 	if v, ok := d.GetOk("repo"); ok {
 		repository.Repo = v.(string)
@@ -50,10 +52,16 @@ func expandRepository(d *schema.ResourceData) *application.Repository {
 		repository.Type = v.(string)
 	}
 	if v, ok := d.GetOk("githubapp_id"); ok {
-		repository.GithubAppId = v.(int64)
+		repository.GithubAppId, err = convertStringToInt64(v.(string))
+		if err != nil {
+			return nil, err
+		}
 	}
 	if v, ok := d.GetOk("githubapp_installation_id"); ok {
-		repository.GithubAppInstallationId = v.(int64)
+		repository.GithubAppInstallationId, err = convertStringToInt64(v.(string))
+		if err != nil {
+			return nil, err
+		}
 	}
 	if v, ok := d.GetOk("githubapp_enterprise_base_url"); ok {
 		repository.GitHubAppEnterpriseBaseURL = v.(string)
@@ -61,7 +69,7 @@ func expandRepository(d *schema.ResourceData) *application.Repository {
 	if v, ok := d.GetOk("githubapp_private_key"); ok {
 		repository.GithubAppPrivateKey = v.(string)
 	}
-	return repository
+	return repository, err
 }
 
 // Flatten
@@ -83,8 +91,8 @@ func flattenRepository(repository *application.Repository, d *schema.ResourceDat
 		//"tls_client_cert_key":     		repository.TLSClientCertKey,
 		"tls_client_cert_data":          repository.TLSClientCertData,
 		"type":                          repository.Type,
-		"githubapp_id":                  repository.GithubAppId,
-		"githubapp_installation_id":     repository.GithubAppInstallationId,
+		"githubapp_id":                  convertInt64ToString(repository.GithubAppId),
+		"githubapp_installation_id":     convertInt64ToString(repository.GithubAppInstallationId),
 		"githubapp_enterprise_base_url": repository.GitHubAppEnterpriseBaseURL,
 	}
 	for k, v := range r {

--- a/argocd/structure_repository_credentials.go
+++ b/argocd/structure_repository_credentials.go
@@ -68,9 +68,13 @@ func flattenRepositoryCredentials(repository application.RepoCreds, d *schema.Re
 		//"ssh_private_key":      repository.SSHPrivateKey,
 		//"tls_client_cert_key":  repository.TLSClientCertKey,
 		"tls_client_cert_data":          repository.TLSClientCertData,
-		"githubapp_id":                  convertInt64ToString(repository.GithubAppId),
-		"githubapp_installation_id":     convertInt64ToString(repository.GithubAppInstallationId),
 		"githubapp_enterprise_base_url": repository.GitHubAppEnterpriseBaseURL,
+	}
+	for repository.GithubAppId > 0 {
+		r["githubapp_id"] = convertInt64ToString(repository.GithubAppId)
+	}
+	for repository.GithubAppInstallationId > 0 {
+		r["githubapp_installation_id"] = convertInt64ToString(repository.GithubAppInstallationId)
 	}
 	for k, v := range r {
 		if err := persistToState(k, v, d); err != nil {

--- a/argocd/structure_repository_credentials.go
+++ b/argocd/structure_repository_credentials.go
@@ -34,16 +34,16 @@ func expandRepositoryCredentials(d *schema.ResourceData) *application.RepoCreds 
 	if v, ok := d.GetOk("enable_oci"); ok {
 		repoCreds.EnableOCI = v.(bool)
 	}
-	if v, ok := d.GetOk("githubApp_id"); ok {
+	if v, ok := d.GetOk("githubapp_id"); ok {
 		repoCreds.GithubAppId = v.(int64)
 	}
-	if v, ok := d.GetOk("githubApp_installation_id"); ok {
+	if v, ok := d.GetOk("githubapp_installation_id"); ok {
 		repoCreds.GithubAppInstallationId = v.(int64)
 	}
-	if v, ok := d.GetOk("githubApp_enterprise_base_url"); ok {
+	if v, ok := d.GetOk("githubapp_enterprise_base_url"); ok {
 		repoCreds.GitHubAppEnterpriseBaseURL = v.(string)
 	}
-	if v, ok := d.GetOk("githubApp_private_key"); ok {
+	if v, ok := d.GetOk("githubapp_private_key"); ok {
 		repoCreds.GithubAppPrivateKey = v.(string)
 	}
 	return repoCreds
@@ -60,9 +60,9 @@ func flattenRepositoryCredentials(repository application.RepoCreds, d *schema.Re
 		//"ssh_private_key":      repository.SSHPrivateKey,
 		//"tls_client_cert_key":  repository.TLSClientCertKey,
 		"tls_client_cert_data":          repository.TLSClientCertData,
-		"githubApp_id":                  repository.GithubAppId,
-		"githubApp_installation_id":     repository.GithubAppInstallationId,
-		"githubApp_enterprise_base_url": repository.GitHubAppEnterpriseBaseURL,
+		"githubapp_id":                  repository.GithubAppId,
+		"githubapp_installation_id":     repository.GithubAppInstallationId,
+		"githubapp_enterprise_base_url": repository.GitHubAppEnterpriseBaseURL,
 	}
 	for k, v := range r {
 		if err := persistToState(k, v, d); err != nil {

--- a/argocd/structure_repository_credentials.go
+++ b/argocd/structure_repository_credentials.go
@@ -11,7 +11,9 @@ import (
 
 // Expand
 
-func expandRepositoryCredentials(d *schema.ResourceData) *application.RepoCreds {
+func expandRepositoryCredentials(d *schema.ResourceData) (*application.RepoCreds, error) {
+	var err error
+
 	repoCreds := &application.RepoCreds{}
 	if v, ok := d.GetOk("url"); ok {
 		repoCreds.URL = v.(string)
@@ -35,10 +37,16 @@ func expandRepositoryCredentials(d *schema.ResourceData) *application.RepoCreds 
 		repoCreds.EnableOCI = v.(bool)
 	}
 	if v, ok := d.GetOk("githubapp_id"); ok {
-		repoCreds.GithubAppId = v.(int64)
+		repoCreds.GithubAppId, err = convertStringToInt64(v.(string))
+		if err != nil {
+			return nil, err
+		}
 	}
 	if v, ok := d.GetOk("githubapp_installation_id"); ok {
-		repoCreds.GithubAppInstallationId = v.(int64)
+		repoCreds.GithubAppInstallationId, err = convertStringToInt64(v.(string))
+		if err != nil {
+			return nil, err
+		}
 	}
 	if v, ok := d.GetOk("githubapp_enterprise_base_url"); ok {
 		repoCreds.GitHubAppEnterpriseBaseURL = v.(string)
@@ -46,7 +54,7 @@ func expandRepositoryCredentials(d *schema.ResourceData) *application.RepoCreds 
 	if v, ok := d.GetOk("githubapp_private_key"); ok {
 		repoCreds.GithubAppPrivateKey = v.(string)
 	}
-	return repoCreds
+	return repoCreds, err
 }
 
 // Flatten
@@ -60,8 +68,8 @@ func flattenRepositoryCredentials(repository application.RepoCreds, d *schema.Re
 		//"ssh_private_key":      repository.SSHPrivateKey,
 		//"tls_client_cert_key":  repository.TLSClientCertKey,
 		"tls_client_cert_data":          repository.TLSClientCertData,
-		"githubapp_id":                  repository.GithubAppId,
-		"githubapp_installation_id":     repository.GithubAppInstallationId,
+		"githubapp_id":                  convertInt64ToString(repository.GithubAppId),
+		"githubapp_installation_id":     convertInt64ToString(repository.GithubAppInstallationId),
 		"githubapp_enterprise_base_url": repository.GitHubAppEnterpriseBaseURL,
 	}
 	for k, v := range r {

--- a/argocd/structure_repository_credentials.go
+++ b/argocd/structure_repository_credentials.go
@@ -34,6 +34,18 @@ func expandRepositoryCredentials(d *schema.ResourceData) *application.RepoCreds 
 	if v, ok := d.GetOk("enable_oci"); ok {
 		repoCreds.EnableOCI = v.(bool)
 	}
+	if v, ok := d.GetOk("githubApp_id"); ok {
+		repoCreds.GithubAppId = v.(int64)
+	}
+	if v, ok := d.GetOk("githubApp_installation_id"); ok {
+		repoCreds.GithubAppInstallationId = v.(int64)
+	}
+	if v, ok := d.GetOk("githubApp_enterprise_base_url"); ok {
+		repoCreds.GitHubAppEnterpriseBaseURL = v.(string)
+	}
+	if v, ok := d.GetOk("githubApp_private_key"); ok {
+		repoCreds.GithubAppPrivateKey = v.(string)
+	}
 	return repoCreds
 }
 
@@ -48,6 +60,9 @@ func flattenRepositoryCredentials(repository application.RepoCreds, d *schema.Re
 		//"ssh_private_key":      repository.SSHPrivateKey,
 		//"tls_client_cert_key":  repository.TLSClientCertKey,
 		"tls_client_cert_data": repository.TLSClientCertData,
+		"githubApp_id": repository.GithubAppId,
+		"githubApp_installation_id": repository.GithubAppInstallationId,
+		"githubApp_enterprise_base_url": repository.GitHubAppEnterpriseBaseURL,
 	}
 	for k, v := range r {
 		if err := persistToState(k, v, d); err != nil {

--- a/argocd/structure_repository_credentials.go
+++ b/argocd/structure_repository_credentials.go
@@ -54,7 +54,7 @@ func expandRepositoryCredentials(d *schema.ResourceData) (*application.RepoCreds
 	if v, ok := d.GetOk("githubapp_private_key"); ok {
 		repoCreds.GithubAppPrivateKey = v.(string)
 	}
-	return repoCreds, err
+	return repoCreds, nil
 }
 
 // Flatten

--- a/argocd/structure_repository_credentials.go
+++ b/argocd/structure_repository_credentials.go
@@ -59,9 +59,9 @@ func flattenRepositoryCredentials(repository application.RepoCreds, d *schema.Re
 		//"password":             repository.Password,
 		//"ssh_private_key":      repository.SSHPrivateKey,
 		//"tls_client_cert_key":  repository.TLSClientCertKey,
-		"tls_client_cert_data": repository.TLSClientCertData,
-		"githubApp_id": repository.GithubAppId,
-		"githubApp_installation_id": repository.GithubAppInstallationId,
+		"tls_client_cert_data":          repository.TLSClientCertData,
+		"githubApp_id":                  repository.GithubAppId,
+		"githubApp_installation_id":     repository.GithubAppInstallationId,
 		"githubApp_enterprise_base_url": repository.GitHubAppEnterpriseBaseURL,
 	}
 	for k, v := range r {

--- a/argocd/validators.go
+++ b/argocd/validators.go
@@ -117,3 +117,12 @@ func validateSSHPrivateKey(value interface{}, key string) (ws []string, es []err
 	}
 	return
 }
+
+func validatePositiveInteger(value interface{}, key string) (ws []string, es []error) {
+	v := value.(string)
+	positiveIntegerRegexp := regexp.MustCompile(`^[+]?\d+?$`)
+	if !positiveIntegerRegexp.MatchString(v) {
+		es = append(es, fmt.Errorf("%s: invalid input '%s'. String input must match a positive integer, e.g.'12345'", key, v))
+	}
+	return
+}

--- a/docs/resources/repository.md
+++ b/docs/resources/repository.md
@@ -40,6 +40,10 @@ resource "argocd_repository" "private" {
 * `tls_client_cert_data` - (Optional), TLS client cert data to authenticate against the repository server.
 * `tls_client_cert_key` - (Optional), TLS client cert key to authenticate against the repository server.
 * `enable_oci` - (Optional), specify whether the repository server should be viewed as OCI compliant.
+* `githubapp_id` - (Optional), int, GitHub App id for authenticating at the repo server only for GitHub repos
+* `githubapp_installation_id` - (Optional), int, GitHub App installation id for authenticating at the repo server only for GitHub repos
+* `githubapp_enterprise_base_url` - (Optional), string, If using GitHub App for a GitHub Enterprise repository the host url is required
+* `githubapp_private_key` - (Optional), string, SSH private key data for GitHub App authentication.
 
 # Exported Attributes
 

--- a/docs/resources/repository.md
+++ b/docs/resources/repository.md
@@ -40,8 +40,8 @@ resource "argocd_repository" "private" {
 * `tls_client_cert_data` - (Optional), TLS client cert data to authenticate against the repository server.
 * `tls_client_cert_key` - (Optional), TLS client cert key to authenticate against the repository server.
 * `enable_oci` - (Optional), specify whether the repository server should be viewed as OCI compliant.
-* `githubapp_id` - (Optional), int, GitHub App id for authenticating at the repo server only for GitHub repos
-* `githubapp_installation_id` - (Optional), int, GitHub App installation id for authenticating at the repo server only for GitHub repos
+* `githubapp_id` - (Optional), string, GitHub App id for authenticating at the repo server only for GitHub repos
+* `githubapp_installation_id` - (Optional), string, GitHub App installation id for authenticating at the repo server only for GitHub repos
 * `githubapp_enterprise_base_url` - (Optional), string, If using GitHub App for a GitHub Enterprise repository the host url is required
 * `githubapp_private_key` - (Optional), string, SSH private key data for GitHub App authentication.
 

--- a/docs/resources/repository_credentials.md
+++ b/docs/resources/repository_credentials.md
@@ -27,8 +27,8 @@ resource "argocd_repository" "private" {
 * `tls_client_cert_data` - (Optional), TLS client cert data to authenticate against the repository server.
 * `tls_client_cert_key` - (Optional), TLS client cert key to authenticate against the repository server.
 * `enable_oci` - (Optional), specify whether the repository server should be viewed as OCI compliant.
-* `githubapp_id` - (Optional), int, GitHub App id for authenticating at the repo server only for GitHub repos
-* `githubapp_installation_id` - (Optional), int, GitHub App installation id for authenticating at the repo server only for GitHub repos
+* `githubapp_id` - (Optional), string, GitHub App id for authenticating at the repo server only for GitHub repos
+* `githubapp_installation_id` - (Optional), string, GitHub App installation id for authenticating at the repo server only for GitHub repos
 * `githubapp_enterprise_base_url` - (Optional), string, If using GitHub App for a GitHub Enterprise repository the host url is required
 * `githubapp_private_key` - (Optional), string, SSH private key data for GitHub App authentication.
 

--- a/docs/resources/repository_credentials.md
+++ b/docs/resources/repository_credentials.md
@@ -27,6 +27,10 @@ resource "argocd_repository" "private" {
 * `tls_client_cert_data` - (Optional), TLS client cert data to authenticate against the repository server.
 * `tls_client_cert_key` - (Optional), TLS client cert key to authenticate against the repository server.
 * `enable_oci` - (Optional), specify whether the repository server should be viewed as OCI compliant.
+* `githubapp_id` - (Optional), int, GitHub App id for authenticating at the repo server only for GitHub repos
+* `githubapp_installation_id` - (Optional), int, GitHub App installation id for authenticating at the repo server only for GitHub repos
+* `githubapp_enterprise_base_url` - (Optional), string, If using GitHub App for a GitHub Enterprise repository the host url is required
+* `githubapp_private_key` - (Optional), string, SSH private key data for GitHub App authentication.
 
 ## Import
 

--- a/docs/resources/repository_credentials.md
+++ b/docs/resources/repository_credentials.md
@@ -2,6 +2,11 @@
 
 Creates ArgoCD repository credentials, for use with future or existing private repositories.
 
+**Note**: due to restrictions in the ArgoCD API the provider is unable to track
+drift in this resource to fields other than `username`. I.e. the provider is
+unable to detect changes to repository credentials that are made outside of
+Terraform (e.g. manual updates to the underlying Kubernetes Secrets). 
+
 ## Example Usage
 
 ```hcl


### PR DESCRIPTION
We need to switch our authentication towards github to GitHub App. As there was also a feature request for this one in the issues, I hence added GitHub App functionality to the following ressources:

- argocd_repository
- argocd_respository_credentials

The underlying package already [supports](https://pkg.go.dev/github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1#RepoCreds) it