### PR TITLE
Fix `argocd_application` state upgrade for `v5.0.0`

### DIFF
--- a/argocd/schema_application.go
+++ b/argocd/schema_application.go
@@ -1804,7 +1804,7 @@ func resourceArgoCDApplicationStateUpgradeV3(_ context.Context, rawState map[str
 
 	syncPolicy := _syncPolicy[0].(map[string]interface{})
 
-	if automated, ok := syncPolicy["automated"].(map[string]bool); ok {
+	if automated, ok := syncPolicy["automated"].(map[string]interface{}); ok {
 		updated := make(map[string]interface{}, 0)
 		for k, v := range automated {
 			updated[k] = v
@@ -1820,7 +1820,7 @@ func resourceArgoCDApplicationStateUpgradeV3(_ context.Context, rawState map[str
 
 	retry := _retry[0].(map[string]interface{})
 
-	if backoff, ok := retry["backoff"].(map[string]string); ok {
+	if backoff, ok := retry["backoff"].(map[string]interface{}); ok {
 		updated := make(map[string]interface{}, 0)
 		for k, v := range backoff {
 			updated[k] = v

--- a/argocd/schema_application_test.go
+++ b/argocd/schema_application_test.go
@@ -246,7 +246,7 @@ func TestUpgradeSchemaApplication_V3V4(t *testing.T) {
 							"namespace": "default",
 						}},
 						"sync_policy": []interface{}{map[string]interface{}{
-							"automated": map[string]bool{
+							"automated": map[string]interface{}{
 								"prune":       true,
 								"self_heal":   true,
 								"allow_empty": true,
@@ -256,7 +256,7 @@ func TestUpgradeSchemaApplication_V3V4(t *testing.T) {
 							},
 							"retry": []interface{}{map[string]interface{}{
 								"limit": "5",
-								"backoff": map[string]string{
+								"backoff": map[string]interface{}{
 									"duration":     "30s",
 									"max_duration": "2m",
 									"factor":       "2",
@@ -336,7 +336,7 @@ func TestUpgradeSchemaApplication_V3V4(t *testing.T) {
 							},
 							"retry": []interface{}{map[string]interface{}{
 								"limit": "5",
-								"backoff": map[string]string{
+								"backoff": map[string]interface{}{
 									"duration":     "30s",
 									"max_duration": "2m",
 									"factor":       "2",
@@ -404,13 +404,13 @@ func TestUpgradeSchemaApplication_V3V4(t *testing.T) {
 							"namespace": "default",
 						}},
 						"sync_policy": []interface{}{map[string]interface{}{
-							"automated": map[string]bool{},
+							"automated": map[string]interface{}{},
 							"sync_options": []string{
 								"Validate=false",
 							},
 							"retry": []interface{}{map[string]interface{}{
 								"limit": "5",
-								"backoff": map[string]string{
+								"backoff": map[string]interface{}{
 									"duration":     "30s",
 									"max_duration": "2m",
 									"factor":       "2",
@@ -479,7 +479,7 @@ func TestUpgradeSchemaApplication_V3V4(t *testing.T) {
 							"namespace": "default",
 						}},
 						"sync_policy": []interface{}{map[string]interface{}{
-							"automated": map[string]bool{
+							"automated": map[string]interface{}{
 								"prune":       true,
 								"self_heal":   true,
 								"allow_empty": true,

--- a/main.go
+++ b/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"flag"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
 	"github.com/oboukili/terraform-provider-argocd/argocd"
@@ -17,7 +19,13 @@ import (
 //go:generate go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs
 
 func main() {
+	var debugMode bool
+	flag.BoolVar(&debugMode, "debug", false, "set to true to run the provider with support for debuggers like delve")
+	flag.Parse()
+
 	plugin.Serve(&plugin.ServeOpts{
+		Debug:        debugMode,
+		ProviderAddr: "registry.terraform.io/oboukili/argocd",
 		ProviderFunc: func() *schema.Provider {
 			return argocd.Provider()
 		},


### PR DESCRIPTION
Fixes state upgrade/migration for `argocd_application` resources in `v5.0.0`.

Also ensures plugin can be run in "debug" mode (kudos to https://opencredo.com/blogs/running-a-terraform-provider-with-a-debugger/ for the technique) - which, allowed me to be able to debug the issue and test this fix.

Closes #236