### PR TITLE
Fix `wait` on update of `argocd_application`

### DIFF
--- a/argocd/resource_argocd_application.go
+++ b/argocd/resource_argocd_application.go
@@ -31,7 +31,7 @@ func resourceArgoCDApplication() *schema.Resource {
 			"spec":     applicationSpecSchemaV4(),
 			"wait": {
 				Type:        schema.TypeBool,
-				Description: "Upon application creation or update, wait for application health/sync status to be healthy/Synced, upon application deletion, wait for application to be removed, when set to true. Wait timeouts are controlled by Terraform Create, Update and Delete resource timeouts (all default to 5 minutes).",
+				Description: "Upon application creation or update, wait for application health/sync status to be healthy/Synced, upon application deletion, wait for application to be removed, when set to true. Wait timeouts are controlled by Terraform Create, Update and Delete resource timeouts (all default to 5 minutes). **Note**: if ArgoCD decides not to sync an application (e.g. because the project to which the application belongs has a `sync_window` applied) then you will a timeout is expected if `wait = true`.",
 				Optional:    true,
 				Default:     false,
 			},
@@ -459,6 +459,9 @@ func resourceArgoCDApplicationUpdate(ctx context.Context, d *schema.ResourceData
 				}
 				if len(list.Items) != 1 {
 					return resource.NonRetryableError(fmt.Errorf("found multiple applications matching name '%s' and namespace '%s'", appName, namespace))
+				}
+				if list.Items[0].Status.ReconciledAt.Equal(apps.Items[0].Status.ReconciledAt) {
+					return resource.RetryableError(fmt.Errorf("reconciliation has not begun"))
 				}
 				if list.Items[0].Status.Health.Status != health.HealthStatusHealthy {
 					return resource.RetryableError(fmt.Errorf("expected application health status to be healthy but was %s", list.Items[0].Status.Health.Status))

--- a/argocd/resource_argocd_application.go
+++ b/argocd/resource_argocd_application.go
@@ -31,7 +31,7 @@ func resourceArgoCDApplication() *schema.Resource {
 			"spec":     applicationSpecSchemaV4(),
 			"wait": {
 				Type:        schema.TypeBool,
-				Description: "Upon application creation or update, wait for application health/sync status to be healthy/Synced, upon application deletion, wait for application to be removed, when set to true. Wait timeouts are controlled by Terraform Create, Update and Delete resource timeouts (all default to 5 minutes). **Note**: if ArgoCD decides not to sync an application (e.g. because the project to which the application belongs has a `sync_window` applied) then you will a timeout is expected if `wait = true`.",
+				Description: "Upon application creation or update, wait for application health/sync status to be healthy/Synced, upon application deletion, wait for application to be removed, when set to true. Wait timeouts are controlled by Terraform Create, Update and Delete resource timeouts (all default to 5 minutes). **Note**: if ArgoCD decides not to sync an application (e.g. because the project to which the application belongs has a `sync_window` applied) then you will experience an expected timeout event if `wait = true`.",
 				Optional:    true,
 				Default:     false,
 			},

--- a/docs/resources/application.md
+++ b/docs/resources/application.md
@@ -145,7 +145,7 @@ resource "argocd_application" "helm" {
 
 - `cascade` (Boolean) Whether to applying cascading deletion when application is removed.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
-- `wait` (Boolean) Upon application creation or update, wait for application health/sync status to be healthy/Synced, upon application deletion, wait for application to be removed, when set to true. Wait timeouts are controlled by Terraform Create, Update and Delete resource timeouts (all default to 5 minutes). **Note**: if ArgoCD decides not to sync an application (e.g. because the project to which the application belongs has a `sync_window` applied) then you will a timeout is expected if `wait = true`.
+- `wait` (Boolean) Upon application creation or update, wait for application health/sync status to be healthy/Synced, upon application deletion, wait for application to be removed, when set to true. Wait timeouts are controlled by Terraform Create, Update and Delete resource timeouts (all default to 5 minutes). **Note**: if ArgoCD decides not to sync an application (e.g. because the project to which the application belongs has a `sync_window` applied) then you will experience an expected timeout event if `wait = true`.
 
 ### Read-Only
 

--- a/docs/resources/application.md
+++ b/docs/resources/application.md
@@ -145,7 +145,7 @@ resource "argocd_application" "helm" {
 
 - `cascade` (Boolean) Whether to applying cascading deletion when application is removed.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
-- `wait` (Boolean) Upon application creation or update, wait for application health/sync status to be healthy/Synced, upon application deletion, wait for application to be removed, when set to true. Wait timeouts are controlled by Terraform Create, Update and Delete resource timeouts (all default to 5 minutes).
+- `wait` (Boolean) Upon application creation or update, wait for application health/sync status to be healthy/Synced, upon application deletion, wait for application to be removed, when set to true. Wait timeouts are controlled by Terraform Create, Update and Delete resource timeouts (all default to 5 minutes). **Note**: if ArgoCD decides not to sync an application (e.g. because the project to which the application belongs has a `sync_window` applied) then you will a timeout is expected if `wait = true`.
 
 ### Read-Only
 


### PR DESCRIPTION
Adds a check on `ReconciledAt` when _waiting_ on application update, ensuring that the update has been processed by ArgoCD (at which point health/sync status will be updated). Note, the update to `ReconciledAt` will occur even if ArgoCD decides not to sync the application (e.g. if a project `sync_window` prevents this). In this scenario, Terraform will eventually timeout with the following error:

``` 
╷
│ Error: something went wrong upon waiting for the application to be updated: expected application sync status to be synced but was OutOfSync
│ 
│   with argocd_application.foo,
│   on application.tf line 1, in resource "argocd_application" "foo":
│    1: resource "argocd_application" "foo" {
│ 
│ expected application sync status to be synced but was OutOfSync
╵
```

Fixes #110