### PR TITLE
Bug fix: interface conversion: interface {} is nil

### DIFF
--- a/argocd/structure_application.go
+++ b/argocd/structure_application.go
@@ -90,7 +90,7 @@ func expandApplicationSource(_as interface{}) (
 }
 
 func expandApplicationSourcePlugin(in []interface{}) *application.ApplicationSourcePlugin {
-	if len(in) == 0 {
+	if len(in) == 0  || in[0] == nil {
 		return nil
 	}
 	a := in[0].(map[string]interface{})


### PR DESCRIPTION
Issue: When defining an empty block of `plugin`, in this way: `plugin { }` , terraform exits with an error:

```
panic: interface conversion: interface {} is nil, not map[string]interface {}

goroutine 40 [running]:
github.com/oboukili/terraform-provider-argocd/argocd.expandApplicationSourcePlugin({0xc000eb8330?, 0xc000565d10?, 0x2f6abaf?})
        github.com/oboukili/terraform-provider-argocd/argocd/structure_application.go:96 +0x372

```

This fix is to keep from terraform failing for that reason.