### PR TITLE
Add support for `include` and `exclude` on directory apps

### DIFF
--- a/argocd/schema_application.go
+++ b/argocd/schema_application.go
@@ -1488,6 +1488,16 @@ func applicationSpecSchemaV4() *schema.Schema {
 												},
 											},
 										},
+										"exclude": {
+											Type:        schema.TypeString,
+											Description: "Glob pattern to match paths against that should be explicitly excluded from being used during manifest generation. This takes precedence over the `include` field. To match multiple patterns, wrap the patterns in {} and separate them with commas. For example: '{config.yaml,env-use2/*}'",
+											Optional:    true,
+										},
+										"include": {
+											Type:        schema.TypeString,
+											Description: "Glob pattern to match paths against that should be explicitly included during manifest generation. If this field is set, only matching manifests will be included. To match multiple patterns, wrap the patterns in {} and separate them with commas. For example: '{*.yml,*.yaml}'",
+											Optional:    true,
+										},
 									},
 								},
 							},

--- a/argocd/structure_application.go
+++ b/argocd/structure_application.go
@@ -141,6 +141,14 @@ func expandApplicationSourceDirectory(in []interface{}) *application.Application
 		result.Recurse = v.(bool)
 	}
 
+	if v, ok := a["exclude"]; ok {
+		result.Exclude = v.(string)
+	}
+
+	if v, ok := a["include"]; ok {
+		result.Include = v.(string)
+	}
+
 	if aj, ok := a["jsonnet"].([]interface{}); ok {
 		jsonnet := application.ApplicationSourceJsonnet{}
 
@@ -662,6 +670,8 @@ func flattenApplicationSourceDirectory(as []*application.ApplicationSourceDirect
 
 			m := make(map[string]interface{})
 			m["recurse"] = a.Recurse
+			m["exclude"] = a.Exclude
+			m["include"] = a.Include
 
 			if len(jsonnet) > 0 {
 				m["jsonnet"] = []map[string][]interface{}{jsonnet}

--- a/docs/resources/application.md
+++ b/docs/resources/application.md
@@ -219,6 +219,8 @@ Optional:
 
 Optional:
 
+- `exclude` (String) Glob pattern to match paths against that should be explicitly excluded from being used during manifest generation. This takes precedence over the `include` field. To match multiple patterns, wrap the patterns in {} and separate them with commas. For example: '{config.yaml,env-use2/*}'
+- `include` (String) Glob pattern to match paths against that should be explicitly included during manifest generation. If this field is set, only matching manifests will be included. To match multiple patterns, wrap the patterns in {} and separate them with commas. For example: '{*.yml,*.yaml}'
 - `jsonnet` (Block List, Max: 1) Jsonnet specific options. (see [below for nested schema](#nestedblock--spec--source--directory--jsonnet))
 - `recurse` (Boolean) Whether to scan a directory recursively for manifests.
 


### PR DESCRIPTION
Closes #208

Notes:
- Feature was introduced prior to `v2.0.0`, so it is available across all versions supported by the provider (hence, no feature/version testing).