### PR TITLE
Allow blank `Group` on cluster resource [white|black]list

### DIFF
--- a/argocd/resource_argocd_project_test.go
+++ b/argocd/resource_argocd_project_test.go
@@ -281,6 +281,14 @@ resource "argocd_project" "simple" {
       group = "rbac.authorization.k8s.io"
       kind  = "ClusterRole"
     }
+    cluster_resource_whitelist {
+      group = ""
+      kind  = "Namespace"
+    }
+    cluster_resource_blacklist {
+      group = ""
+      kind  = "ResourceQuota"
+    }
     cluster_resource_blacklist {
       group = "*"
       kind  = "*"

--- a/argocd/validators.go
+++ b/argocd/validators.go
@@ -73,9 +73,6 @@ func validateRoleName(value interface{}, key string) (ws []string, es []error) {
 
 func validateGroupName(value interface{}, key string) (ws []string, es []error) {
 	v := value.(string)
-	if strings.TrimSpace(v) == "" {
-		es = append(es, fmt.Errorf("%s: group '%s' is empty", key, v))
-	}
 
 	invalidChars := regexp.MustCompile("[,\n\r\t]")
 	if invalidChars.MatchString(v) {


### PR DESCRIPTION
For reference, see [project.yaml](https://argo-cd.readthedocs.io/en/stable/operator-manual/project.yaml), which gives examples of using a blank group for various resources.

Closes #257 