### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,64 @@
+---
+name: "\U0001F41B Bug Report"
+about: "If something isn't working as expected \U0001F914."
+title: ''
+labels: bug
+
+---
+
+<!---
+Hi there,
+
+Thank you for opening an issue. Please provide as much detail as possible when reporting issue as this benefits all parties and will most likely lead to a quicker resolution of the issue.
+--->
+
+
+### Terraform Version, ArgoCD Provider Version and ArgoCD Version
+<!--- Run `terraform -v` to show the version. If you are not running the latest version of Terraform, please upgrade because your issue may have already been fixed. --->
+```
+Terraform version:
+ArgoCD provider version:
+ArgoCD version:
+```
+
+### Affected Resource(s)
+<!-- Please list the resources as a list, for example:
+- argocd_application
+- argocd_cluster
+If this issue appears to affect multiple resources, it may be an issue with Terraform's core, so please mention this. -->
+
+### Terraform Configuration Files
+```hcl
+# Copy-paste your Terraform configurations here - for large Terraform configs,
+# please use a service like Dropbox and share a link to the ZIP file. For
+# security, you can also encrypt the files using our GPG public key.
+```
+
+### Debug Output
+<!--Please provider a link to a GitHub Gist containing the complete debug output: https://www.terraform.io/docs/internals/debugging.html. Please do NOT paste the debug output in the issue; just paste a link to the Gist. -->
+
+### Panic Output
+<!--If Terraform produced a panic, please provide a link to a GitHub Gist containing the output of the `crash.log` -->
+
+### Steps to Reproduce
+<!-- Please list the steps required to reproduce the issue, for example:
+1. `terraform apply` -->
+
+### Expected Behavior
+<!-- What should have happened? -->
+
+### Actual Behavior
+<!-- What actually happened? -->
+
+### Important Factoids
+<!-- Are there anything atypical about your accounts that we should know? For example: For general provider/connectivity issues, how is your ArgoCD server exposed? When dealing with cluster resources, what type of cluster are you referencing (where is it hosted)?  -->
+
+### References
+<!--Are there any other GitHub issues (open or closed) or Pull Requests that should be linked here? For example:
+- GH-1234
+-->
+
+### Community Note
+<!--- Please keep this note for the community --->
+* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
+* If you are interested in working on this issue or have submitted a pull request, please leave a comment

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,36 @@
+--
+name: "\U0001F680 Feature Request"
+about: "I have a suggestion (and might want to implement myself \U0001F642)!"
+title: ''
+labels: enhancement
+
+--
+
+
+### Description
+
+<!-- Please leave a helpful description of the feature request here. -->
+
+### Potential Terraform Configuration
+<!-- Information about code formatting: https://help.github.com/articles/basic-writing-and-formatting-syntax/#quoting-code -->
+
+```hcl
+# Copy-paste your Terraform configurations here - for large Terraform configs,
+# please use a service like Dropbox and share a link to the ZIP file. For
+# security, you can also encrypt the files using our GPG public key.
+```
+
+### References
+<!-- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests
+
+Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
+-->
+
+<!-- Please keep this note for the community -->
+
+### Community Note
+
+* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
+* If you are interested in working on this issue or have submitted a pull request, please leave a comment
+
+<!-- Thank you for keeping this note for the community -->

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,31 @@
+---
+name: "\U0001F914 Question"
+about: "If you need help figuring something out"
+title: ''
+labels: question
+
+---
+
+<!---
+Hi, 
+
+Please provide as much information as possible when asking your question. 
+
+Please understand that we make a best effort attempt to address questions, but our focus is on provider development. It's still valuable to ask your question because you may receive help from the community, and help us understand common asks.
+-->
+
+### Terraform Version, ArgoCD Provider Version and ArgoCD Version
+<!--- Run `terraform -v` to show the version. If you are not running the latest version of Terraform, please upgrade because your issue may have already been fixed. --->
+```
+Terraform version:
+ArgoCD provider version:
+ArgoCD version:
+```
+
+## Terraform configuration
+```hcl
+# Enter your configuration here.
+```
+
+## Question
+<!-- Enter your question here. -->


### PR DESCRIPTION
Adds issue templates to this repository to try and improve the _quality_ of any issues that are opened (thereby making them easier to respond to). Templates have been (largely) taken from https://github.com/hashicorp/terraform-provider-kubernetes/tree/main/.github/ISSUE_TEMPLATE