### PR TITLE
Fix "Feature Request" issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,10 +1,10 @@
---
+---
 name: "\U0001F680 Feature Request"
 about: "I have a suggestion (and might want to implement myself \U0001F642)!"
 title: ''
 labels: enhancement
 
---
+---
 
 
 ### Description


### PR DESCRIPTION
The template currently isn't showing up in "New Issue" due to issues with metadata/header section that were introduced when I was editing #259 :see_no_evil:

![Screenshot from 2023-04-18 22-34-09](https://user-images.githubusercontent.com/878612/232899259-5571cba6-41f7-42f4-b558-7e2cb8920281.png)
