### PR TITLE
Fix locking on resources during Terraform actions

### DIFF
--- a/argocd/resource_argocd_project.go
+++ b/argocd/resource_argocd_project.go
@@ -235,24 +235,31 @@ func resourceArgoCDProjectUpdate(ctx context.Context, d *schema.ResourceData, me
 
 	projectName := objectMeta.Name
 
-	if _, ok := tokenMutexProjectMap[projectName]; !ok {
-		tokenMutexProjectMap[projectName] = &sync.RWMutex{}
-	}
-
-	tokenMutexProjectMap[projectName].RLock()
-	p, err := si.ProjectClient.Get(ctx, &projectClient.ProjectQuery{
-		Name: d.Id(),
-	})
-	tokenMutexProjectMap[projectName].RUnlock()
-
+	featureProjectSourceNamespacesSupported, err := si.isFeatureSupported(featureProjectSourceNamespaces)
 	if err != nil {
 		return []diag.Diagnostic{
 			{
 				Severity: diag.Error,
-				Summary:  "failed to get project",
+				Summary:  "feature not supported",
 				Detail:   err.Error(),
 			},
 		}
+	} else if !featureProjectSourceNamespacesSupported {
+		_, sourceNamespacesOk := d.GetOk("spec.0.source_namespaces")
+		if sourceNamespacesOk {
+			return []diag.Diagnostic{
+				{
+					Severity: diag.Error,
+					Summary: fmt.Sprintf(
+						"project source_namespaces is only supported from ArgoCD %s onwards",
+						featureVersionConstraintsMap[featureProjectSourceNamespaces].String()),
+				},
+			}
+		}
+	}
+
+	if _, ok := tokenMutexProjectMap[projectName]; !ok {
+		tokenMutexProjectMap[projectName] = &sync.RWMutex{}
 	}
 
 	projectRequest := &projectClient.ProjectUpdateRequest{
@@ -262,7 +269,22 @@ func resourceArgoCDProjectUpdate(ctx context.Context, d *schema.ResourceData, me
 		},
 	}
 
-	if p != nil {
+	tokenMutexProjectMap[projectName].Lock()
+
+	p, err := si.ProjectClient.Get(ctx, &projectClient.ProjectQuery{
+		Name: d.Id(),
+	})
+	if err != nil {
+		tokenMutexProjectMap[projectName].Unlock()
+
+		return []diag.Diagnostic{
+			{
+				Severity: diag.Error,
+				Summary:  fmt.Sprintf("failed to get existing project %s", projectName),
+				Detail:   err.Error(),
+			},
+		}
+	} else if p != nil {
 		// Kubernetes API requires providing the up-to-date correct ResourceVersion for updates
 		projectRequest.Project.ResourceVersion = p.ResourceVersion
 
@@ -279,6 +301,8 @@ func resourceArgoCDProjectUpdate(ctx context.Context, d *schema.ResourceData, me
 				// i == -1 means the role does not exist
 				// and was recently added within Terraform tf files
 				if i != -1 {
+					tokenMutexProjectMap[projectName].Unlock()
+
 					return []diag.Diagnostic{
 						{
 							Severity: diag.Error,
@@ -293,8 +317,8 @@ func resourceArgoCDProjectUpdate(ctx context.Context, d *schema.ResourceData, me
 		}
 	}
 
-	tokenMutexProjectMap[projectName].Lock()
 	_, err = si.ProjectClient.Update(ctx, projectRequest)
+
 	tokenMutexProjectMap[projectName].Unlock()
 
 	if err != nil {

--- a/argocd/resource_argocd_project.go
+++ b/argocd/resource_argocd_project.go
@@ -68,37 +68,6 @@ func resourceArgoCDProjectCreate(ctx context.Context, d *schema.ResourceData, me
 
 	projectName := objectMeta.Name
 
-	if _, ok := tokenMutexProjectMap[projectName]; !ok {
-		tokenMutexProjectMap[projectName] = &sync.RWMutex{}
-	}
-
-	tokenMutexProjectMap[projectName].RLock()
-	p, err := si.ProjectClient.Get(ctx, &projectClient.ProjectQuery{
-		Name: projectName,
-	})
-	tokenMutexProjectMap[projectName].RUnlock()
-
-	if err != nil {
-		if !strings.Contains(err.Error(), "NotFound") {
-			return []diag.Diagnostic{
-				{
-					Severity: diag.Error,
-					Summary:  fmt.Sprintf("Project %s could not be created", projectName),
-					Detail:   err.Error(),
-				},
-			}
-		}
-	}
-
-	if p != nil {
-		switch p.DeletionTimestamp {
-		case nil:
-		default:
-			// Pre-existing project is still in Kubernetes soft deletion queue
-			time.Sleep(time.Duration(*p.DeletionGracePeriodSeconds))
-		}
-	}
-
 	featureProjectSourceNamespacesSupported, err := si.isFeatureSupported(featureProjectSourceNamespaces)
 	if err != nil {
 		return []diag.Diagnostic{
@@ -122,7 +91,34 @@ func resourceArgoCDProjectCreate(ctx context.Context, d *schema.ResourceData, me
 		}
 	}
 
+	if _, ok := tokenMutexProjectMap[projectName]; !ok {
+		tokenMutexProjectMap[projectName] = &sync.RWMutex{}
+	}
+
 	tokenMutexProjectMap[projectName].Lock()
+
+	p, err := si.ProjectClient.Get(ctx, &projectClient.ProjectQuery{
+		Name: projectName,
+	})
+	if err != nil && !strings.Contains(err.Error(), "NotFound") {
+		tokenMutexProjectMap[projectName].Unlock()
+
+		return []diag.Diagnostic{
+			{
+				Severity: diag.Error,
+				Summary:  fmt.Sprintf("failed to get project %s", projectName),
+				Detail:   err.Error(),
+			},
+		}
+	} else if p != nil {
+		switch p.DeletionTimestamp {
+		case nil:
+		default:
+			// Pre-existing project is still in Kubernetes soft deletion queue
+			time.Sleep(time.Duration(*p.DeletionGracePeriodSeconds))
+		}
+	}
+
 	p, err = si.ProjectClient.Create(ctx, &projectClient.ProjectCreateRequest{
 		Project: &application.AppProject{
 			ObjectMeta: objectMeta,
@@ -132,6 +128,7 @@ func resourceArgoCDProjectCreate(ctx context.Context, d *schema.ResourceData, me
 		// TODO: make that a resource flag with proper acceptance tests
 		Upsert: false,
 	})
+
 	tokenMutexProjectMap[projectName].Unlock()
 
 	if err != nil {

--- a/argocd/resource_argocd_project.go
+++ b/argocd/resource_argocd_project.go
@@ -242,13 +242,6 @@ func resourceArgoCDProjectUpdate(ctx context.Context, d *schema.ResourceData, me
 		tokenMutexProjectMap[projectName] = &sync.RWMutex{}
 	}
 
-	projectRequest := &projectClient.ProjectUpdateRequest{
-		Project: &application.AppProject{
-			ObjectMeta: objectMeta,
-			Spec:       spec,
-		},
-	}
-
 	tokenMutexProjectMap[projectName].RLock()
 	p, err := si.ProjectClient.Get(ctx, &projectClient.ProjectQuery{
 		Name: d.Id(),
@@ -263,6 +256,13 @@ func resourceArgoCDProjectUpdate(ctx context.Context, d *schema.ResourceData, me
 				Detail:   err.Error(),
 			},
 		}
+	}
+
+	projectRequest := &projectClient.ProjectUpdateRequest{
+		Project: &application.AppProject{
+			ObjectMeta: objectMeta,
+			Spec:       spec,
+		},
 	}
 
 	if p != nil {

--- a/argocd/resource_argocd_project_token.go
+++ b/argocd/resource_argocd_project_token.go
@@ -564,7 +564,12 @@ func resourceArgoCDProjectTokenDelete(ctx context.Context, d *schema.ResourceDat
 	}
 
 	tokenMutexProjectMap[projectName].Lock()
-	if _, err := si.ProjectClient.DeleteToken(ctx, opts); err != nil {
+
+	_, err = si.ProjectClient.DeleteToken(ctx, opts)
+
+	tokenMutexProjectMap[projectName].Unlock()
+
+	if err != nil {
 		return []diag.Diagnostic{
 			{
 				Severity: diag.Error,
@@ -573,7 +578,6 @@ func resourceArgoCDProjectTokenDelete(ctx context.Context, d *schema.ResourceDat
 			},
 		}
 	}
-	tokenMutexProjectMap[projectName].Unlock()
 
 	d.SetId("")
 

--- a/argocd/resource_argocd_project_token_test.go
+++ b/argocd/resource_argocd_project_token_test.go
@@ -110,7 +110,7 @@ func TestAccArgoCDProjectToken_RenewBefore(t *testing.T) {
 func TestAccArgoCDProjectToken_RenewAfter(t *testing.T) {
 	resourceName := "argocd_project_token.renew_after"
 
-	renewAfterSeconds := 1
+	renewAfterSeconds := 2
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
@@ -120,16 +120,20 @@ func TestAccArgoCDProjectToken_RenewAfter(t *testing.T) {
 				Config: testAccArgoCDProjectTokenRenewAfter(renewAfterSeconds),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "renew_after", fmt.Sprintf("%ds", renewAfterSeconds)),
-					testDelay(renewAfterSeconds+1),
 				),
-				ExpectNonEmptyPlan: true,
 			},
 			{
 				Config: testAccArgoCDProjectTokenRenewAfter(renewAfterSeconds),
 				Check: resource.ComposeTestCheckFunc(
-					testDelay(renewAfterSeconds),
+					testDelay(renewAfterSeconds + 1),
 				),
 				ExpectNonEmptyPlan: true, // token should be recreated when refreshed at end of step due to delay above
+			},
+			{
+				Config: testAccArgoCDProjectTokenRenewAfter(renewAfterSeconds),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "renew_after", fmt.Sprintf("%ds", renewAfterSeconds)),
+				),
 			},
 		},
 	})

--- a/argocd/resource_argocd_repository.go
+++ b/argocd/resource_argocd_repository.go
@@ -91,7 +91,7 @@ func resourceArgoCDRepositoryCreate(ctx context.Context, d *schema.ResourceData,
 				return resource.RetryableError(fmt.Errorf("handshake failed for repository %s, retrying in case a repository certificate has been set recently", repo.Repo))
 			}
 
-			return resource.NonRetryableError(fmt.Errorf("repository %s not found: %s", repo.Repo, err))
+			return resource.NonRetryableError(fmt.Errorf("failed to create repository %s : %w", repo.Repo, err))
 		} else if r == nil {
 			return resource.NonRetryableError(fmt.Errorf("ArgoCD did not return an error or a repository result: %s", err))
 		} else if r.ConnectionState.Status == application.ConnectionStatusFailed {

--- a/argocd/resource_argocd_repository.go
+++ b/argocd/resource_argocd_repository.go
@@ -139,7 +139,7 @@ func resourceArgoCDRepositoryRead(ctx context.Context, d *schema.ResourceData, m
 		}
 	}
 
-	r := &application.Repository{}
+	var r *application.Repository
 
 	if featureRepositoryGetSupported {
 		tokenMutexConfiguration.RLock()


### PR DESCRIPTION
~This PR addresses the flaky cluster tests by fixing the locking mechanism used to control the concurrent provisioning of resources via the provider. The existing mechanism is flawed in that locks are only maintained for individual calls to the API, thereby allowing cases where for example:~
~- a delete may occur in the middle of the update of an existing resource~
~- two creates of identical resources may run at the same time leading to a plan diff~

~Examples of both can be seen in the logs [here](https://github.com/oboukili/terraform-provider-argocd/actions/runs/4789891646/jobs/8519015272).~

~The change in this PR ensures that a single lock is maintained for the full Terraform CRUD action (and all API calls required to complete it). Also, since the same locking pattern is used across a number of resources, I have taken the opportunity to fix this across the codebase rather than just the cluster resource.~