### PR TITLE
Prevent duplicate clusters ending up in Terraform state

### DIFF
--- a/argocd/resource_argocd_cluster.go
+++ b/argocd/resource_argocd_cluster.go
@@ -127,7 +127,7 @@ func resourceArgoCDClusterCreate(ctx context.Context, d *schema.ResourceData, me
 
 	tokenMutexClusters.Lock()
 	c, err := client.Create(ctx, &clusterClient.ClusterCreateRequest{
-		Cluster: cluster, Upsert: true})
+		Cluster: cluster, Upsert: false})
 	tokenMutexClusters.Unlock()
 
 	if err != nil {

--- a/argocd/resource_argocd_cluster.go
+++ b/argocd/resource_argocd_cluster.go
@@ -90,17 +90,20 @@ func resourceArgoCDClusterCreate(ctx context.Context, d *schema.ResourceData, me
 
 	client := *server.ClusterClient
 
+	// Need a full lock here to avoid race conditions between List existing clusters and creating a new one
+	tokenMutexClusters.Lock()
+
 	// Cluster are unique by "server address" so we should check there is no existing cluster with this address before
-	tokenMutexClusters.RLock()
 	existingClusters, err := client.List(ctx, &clusterClient.ClusterQuery{
 		Id: &clusterClient.ClusterID{
 			Type:  "server",
 			Value: cluster.Server, // TODO: not used by backend, upstream bug ?
 		},
 	})
-	tokenMutexClusters.RUnlock()
 
 	if err != nil {
+		tokenMutexClusters.Unlock()
+
 		return []diag.Diagnostic{
 			{
 				Severity: diag.Error,
@@ -115,6 +118,8 @@ func resourceArgoCDClusterCreate(ctx context.Context, d *schema.ResourceData, me
 	if len(existingClusters.Items) > 0 {
 		for _, existingCluster := range existingClusters.Items {
 			if rtrimmedServer == strings.TrimRight(existingCluster.Server, "/") {
+				tokenMutexClusters.Unlock()
+
 				return []diag.Diagnostic{
 					{
 						Severity: diag.Error,
@@ -125,7 +130,6 @@ func resourceArgoCDClusterCreate(ctx context.Context, d *schema.ResourceData, me
 		}
 	}
 
-	tokenMutexClusters.Lock()
 	c, err := client.Create(ctx, &clusterClient.ClusterCreateRequest{
 		Cluster: cluster, Upsert: false})
 	tokenMutexClusters.Unlock()


### PR DESCRIPTION
This PR aims to address the currently flaky invalid cluster tests in a less _invasive_ manner than #263, which requires further thought with regard to the performance implications. 

When looking at this in more detail, I identified 3 separate issues that resulted in these tests being flaky.

- We shouldn't be testing whether attributes are set on tests that are designed to return errors. This is because the order in which the "duplicate" resources are applied is non-deterministic, and so sometimes resource 1 gets applied, and resource 2 causes the error, and other times it is the other way around. Thus we end up with errors such as:
``` 
resource_argocd_cluster_test.go:343: Step 1/1, expected an error with pattern, no match on: Check failed: Check 3/3 error: argocd_cluster.cluster_one: Attribute 'name' expected "90kh6rtvum", got "server"
``` 

- `Upsert` was set to `false` when calling `Create` on the cluster client. This meant that we can end up in a situation whereby two Terraform resources are managing the same resource in ArgoCD. This leads to perpetual diffs on these resources and also results in errors like the following when the resources in the tests are subsequently destroyed.

```
--- FAIL: TestAccArgoCDCluster_invalidSameServer (7.94s)
    resource_argocd_cluster_test.go:277: Step 3/3, expected an error with pattern, no match on: After applying this test step, the plan was not empty.
        stdout:
        
        
        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
          ~ update in-place
        
        Terraform will perform the following actions:
        
          # argocd_cluster.cluster_with_trailing_slash will be updated in-place
          ~ resource "argocd_cluster" "cluster_with_trailing_slash" {
                id     = "https://kubernetes.default.svc.cluster.local/server"
                name   = "server"
              ~ server = "https://kubernetes.default.svc.cluster.local" -> "https://kubernetes.default.svc.cluster.local/"
                # (1 unchanged attribute hidden)
        
                # (1 unchanged block hidden)
            }
        
        Plan: 0 to add, 1 to change, 0 to destroy.
    testing_new.go:84: Error running post-test destroy, there may be dangling resources: exit status 1
        
        Error: something went wrong during cluster deletion: rpc error: code = PermissionDenied desc = permission denied
        
        rpc error: code = PermissionDenied desc = permission denied
FAIL
```

- Finally, the situation above (whereby two resources end up being created in our tests) is the result of a race condition due to the locking pattern in place on the `Create` method. If both resources are created simultaneously, then both can pass the "distinct cluster" checks covered by the RLock, allowing both resources to be created and end up in Terraform state. So, both the Get and Create calls need to be covered by a full RW lock as per the implementation in [argocd_repository_certificate.go](https://github.com/oboukili/terraform-provider-argocd/blob/50f550a4e4ca32bfd0a199c1443815062d85cc59/argocd/resource_argocd_repository_certificate.go#L62-L63).
