### PR TITLE
Drop use of pointers on clients

### DIFF
--- a/argocd/features.go
+++ b/argocd/features.go
@@ -48,13 +48,13 @@ var featureVersionConstraintsMap = map[int]*semver.Version{
 }
 
 type ServerInterface struct {
-	ApiClient            *apiclient.Client
-	ApplicationClient    *application.ApplicationServiceClient
-	CertificateClient    *certificate.CertificateServiceClient
-	ClusterClient        *cluster.ClusterServiceClient
-	ProjectClient        *project.ProjectServiceClient
-	RepositoryClient     *repository.RepositoryServiceClient
-	RepoCredsClient      *repocreds.RepoCredsServiceClient
+	ApiClient            apiclient.Client
+	ApplicationClient    application.ApplicationServiceClient
+	CertificateClient    certificate.CertificateServiceClient
+	ClusterClient        cluster.ClusterServiceClient
+	ProjectClient        project.ProjectServiceClient
+	RepositoryClient     repository.RepositoryServiceClient
+	RepoCredsClient      repocreds.RepoCredsServiceClient
 	ServerVersion        *semver.Version
 	ServerVersionMessage *version.VersionMessage
 	ProviderData         *schema.ResourceData
@@ -79,64 +79,64 @@ func (p *ServerInterface) initClients(ctx context.Context) error {
 			return err
 		}
 
-		p.ApiClient = &apiClient
+		p.ApiClient = apiClient
 	}
 
 	if p.ClusterClient == nil {
-		_, clusterClient, err := (*p.ApiClient).NewClusterClient()
+		_, clusterClient, err := p.ApiClient.NewClusterClient()
 		if err != nil {
 			return err
 		}
 
-		p.ClusterClient = &clusterClient
+		p.ClusterClient = clusterClient
 	}
 
 	if p.CertificateClient == nil {
-		_, certClient, err := (*p.ApiClient).NewCertClient()
+		_, certClient, err := p.ApiClient.NewCertClient()
 		if err != nil {
 			return err
 		}
 
-		p.CertificateClient = &certClient
+		p.CertificateClient = certClient
 	}
 
 	if p.ApplicationClient == nil {
-		_, applicationClient, err := (*p.ApiClient).NewApplicationClient()
+		_, applicationClient, err := p.ApiClient.NewApplicationClient()
 		if err != nil {
 			return err
 		}
 
-		p.ApplicationClient = &applicationClient
+		p.ApplicationClient = applicationClient
 	}
 
 	if p.ProjectClient == nil {
-		_, projectClient, err := (*p.ApiClient).NewProjectClient()
+		_, projectClient, err := p.ApiClient.NewProjectClient()
 		if err != nil {
 			return err
 		}
 
-		p.ProjectClient = &projectClient
+		p.ProjectClient = projectClient
 	}
 
 	if p.RepositoryClient == nil {
-		_, repositoryClient, err := (*p.ApiClient).NewRepoClient()
+		_, repositoryClient, err := p.ApiClient.NewRepoClient()
 		if err != nil {
 			return err
 		}
 
-		p.RepositoryClient = &repositoryClient
+		p.RepositoryClient = repositoryClient
 	}
 
 	if p.RepoCredsClient == nil {
-		_, repoCredsClient, err := (*p.ApiClient).NewRepoCredsClient()
+		_, repoCredsClient, err := p.ApiClient.NewRepoCredsClient()
 		if err != nil {
 			return err
 		}
 
-		p.RepoCredsClient = &repoCredsClient
+		p.RepoCredsClient = repoCredsClient
 	}
 
-	acCloser, versionClient, err := (*p.ApiClient).NewVersionClient()
+	acCloser, versionClient, err := p.ApiClient.NewVersionClient()
 	if err != nil {
 		return err
 	}

--- a/argocd/resource_argocd_project.go
+++ b/argocd/resource_argocd_project.go
@@ -44,8 +44,8 @@ func resourceArgoCDProject() *schema.Resource {
 }
 
 func resourceArgoCDProjectCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	server := meta.(*ServerInterface)
-	if err := server.initClients(ctx); err != nil {
+	si := meta.(*ServerInterface)
+	if err := si.initClients(ctx); err != nil {
 		return []diag.Diagnostic{
 			{
 				Severity: diag.Error,
@@ -66,7 +66,6 @@ func resourceArgoCDProjectCreate(ctx context.Context, d *schema.ResourceData, me
 		}
 	}
 
-	c := *server.ProjectClient
 	projectName := objectMeta.Name
 
 	if _, ok := tokenMutexProjectMap[projectName]; !ok {
@@ -74,7 +73,7 @@ func resourceArgoCDProjectCreate(ctx context.Context, d *schema.ResourceData, me
 	}
 
 	tokenMutexProjectMap[projectName].RLock()
-	p, err := c.Get(ctx, &projectClient.ProjectQuery{
+	p, err := si.ProjectClient.Get(ctx, &projectClient.ProjectQuery{
 		Name: projectName,
 	})
 	tokenMutexProjectMap[projectName].RUnlock()
@@ -100,7 +99,7 @@ func resourceArgoCDProjectCreate(ctx context.Context, d *schema.ResourceData, me
 		}
 	}
 
-	featureProjectSourceNamespacesSupported, err := server.isFeatureSupported(featureProjectSourceNamespaces)
+	featureProjectSourceNamespacesSupported, err := si.isFeatureSupported(featureProjectSourceNamespaces)
 	if err != nil {
 		return []diag.Diagnostic{
 			{
@@ -124,7 +123,7 @@ func resourceArgoCDProjectCreate(ctx context.Context, d *schema.ResourceData, me
 	}
 
 	tokenMutexProjectMap[projectName].Lock()
-	p, err = c.Create(ctx, &projectClient.ProjectCreateRequest{
+	p, err = si.ProjectClient.Create(ctx, &projectClient.ProjectCreateRequest{
 		Project: &application.AppProject{
 			ObjectMeta: objectMeta,
 			Spec:       spec,
@@ -159,8 +158,8 @@ func resourceArgoCDProjectCreate(ctx context.Context, d *schema.ResourceData, me
 }
 
 func resourceArgoCDProjectRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	server := meta.(*ServerInterface)
-	if err := server.initClients(ctx); err != nil {
+	si := meta.(*ServerInterface)
+	if err := si.initClients(ctx); err != nil {
 		return []diag.Diagnostic{
 			{
 				Severity: diag.Error,
@@ -170,7 +169,6 @@ func resourceArgoCDProjectRead(ctx context.Context, d *schema.ResourceData, meta
 		}
 	}
 
-	c := *server.ProjectClient
 	projectName := d.Id()
 
 	if _, ok := tokenMutexProjectMap[projectName]; !ok {
@@ -178,7 +176,7 @@ func resourceArgoCDProjectRead(ctx context.Context, d *schema.ResourceData, meta
 	}
 
 	tokenMutexProjectMap[projectName].RLock()
-	p, err := c.Get(ctx, &projectClient.ProjectQuery{
+	p, err := si.ProjectClient.Get(ctx, &projectClient.ProjectQuery{
 		Name: projectName,
 	})
 	tokenMutexProjectMap[projectName].RUnlock()
@@ -216,8 +214,8 @@ func resourceArgoCDProjectUpdate(ctx context.Context, d *schema.ResourceData, me
 		return resourceArgoCDProjectRead(ctx, d, meta)
 	}
 
-	server := meta.(*ServerInterface)
-	if err := server.initClients(ctx); err != nil {
+	si := meta.(*ServerInterface)
+	if err := si.initClients(ctx); err != nil {
 		return []diag.Diagnostic{
 			{
 				Severity: diag.Error,
@@ -238,7 +236,6 @@ func resourceArgoCDProjectUpdate(ctx context.Context, d *schema.ResourceData, me
 		}
 	}
 
-	c := *server.ProjectClient
 	projectName := objectMeta.Name
 
 	if _, ok := tokenMutexProjectMap[projectName]; !ok {
@@ -253,7 +250,7 @@ func resourceArgoCDProjectUpdate(ctx context.Context, d *schema.ResourceData, me
 	}
 
 	tokenMutexProjectMap[projectName].RLock()
-	p, err := c.Get(ctx, &projectClient.ProjectQuery{
+	p, err := si.ProjectClient.Get(ctx, &projectClient.ProjectQuery{
 		Name: d.Id(),
 	})
 	tokenMutexProjectMap[projectName].RUnlock()
@@ -300,7 +297,7 @@ func resourceArgoCDProjectUpdate(ctx context.Context, d *schema.ResourceData, me
 	}
 
 	tokenMutexProjectMap[projectName].Lock()
-	_, err = c.Update(ctx, projectRequest)
+	_, err = si.ProjectClient.Update(ctx, projectRequest)
 	tokenMutexProjectMap[projectName].Unlock()
 
 	if err != nil {
@@ -317,8 +314,8 @@ func resourceArgoCDProjectUpdate(ctx context.Context, d *schema.ResourceData, me
 }
 
 func resourceArgoCDProjectDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	server := meta.(*ServerInterface)
-	if err := server.initClients(ctx); err != nil {
+	si := meta.(*ServerInterface)
+	if err := si.initClients(ctx); err != nil {
 		return []diag.Diagnostic{
 			{
 				Severity: diag.Error,
@@ -328,7 +325,6 @@ func resourceArgoCDProjectDelete(ctx context.Context, d *schema.ResourceData, me
 		}
 	}
 
-	c := *server.ProjectClient
 	projectName := d.Id()
 
 	if _, ok := tokenMutexProjectMap[projectName]; !ok {
@@ -336,7 +332,7 @@ func resourceArgoCDProjectDelete(ctx context.Context, d *schema.ResourceData, me
 	}
 
 	tokenMutexProjectMap[projectName].Lock()
-	_, err := c.Delete(ctx, &projectClient.ProjectQuery{Name: projectName})
+	_, err := si.ProjectClient.Delete(ctx, &projectClient.ProjectQuery{Name: projectName})
 	tokenMutexProjectMap[projectName].Unlock()
 
 	if err != nil && !strings.Contains(err.Error(), "NotFound") {

--- a/argocd/resource_argocd_repository.go
+++ b/argocd/resource_argocd_repository.go
@@ -28,8 +28,8 @@ func resourceArgoCDRepository() *schema.Resource {
 }
 
 func resourceArgoCDRepositoryCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	server := meta.(*ServerInterface)
-	if err := server.initClients(ctx); err != nil {
+	si := meta.(*ServerInterface)
+	if err := si.initClients(ctx); err != nil {
 		return []diag.Diagnostic{
 			{
 				Severity: diag.Error,
@@ -38,8 +38,6 @@ func resourceArgoCDRepositoryCreate(ctx context.Context, d *schema.ResourceData,
 			},
 		}
 	}
-
-	c := *server.RepositoryClient
 
 	repo, err := expandRepository(d)
 	if err != nil {
@@ -52,7 +50,7 @@ func resourceArgoCDRepositoryCreate(ctx context.Context, d *schema.ResourceData,
 		}
 	}
 
-	featureProjectScopedRepositoriesSupported, err := server.isFeatureSupported(featureProjectScopedRepositories)
+	featureProjectScopedRepositoriesSupported, err := si.isFeatureSupported(featureProjectScopedRepositories)
 	if err != nil {
 		return []diag.Diagnostic{
 			{
@@ -78,7 +76,7 @@ func resourceArgoCDRepositoryCreate(ctx context.Context, d *schema.ResourceData,
 
 		var r *application.Repository
 
-		r, err = c.CreateRepository(
+		r, err = si.RepositoryClient.CreateRepository(
 			ctx,
 			&repository.RepoCreateRequest{
 				Repo:   repo,
@@ -119,8 +117,8 @@ func resourceArgoCDRepositoryCreate(ctx context.Context, d *schema.ResourceData,
 }
 
 func resourceArgoCDRepositoryRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	server := meta.(*ServerInterface)
-	if err := server.initClients(ctx); err != nil {
+	si := meta.(*ServerInterface)
+	if err := si.initClients(ctx); err != nil {
 		return []diag.Diagnostic{
 			{
 				Severity: diag.Error,
@@ -130,10 +128,7 @@ func resourceArgoCDRepositoryRead(ctx context.Context, d *schema.ResourceData, m
 		}
 	}
 
-	c := *server.RepositoryClient
-	r := &application.Repository{}
-
-	featureRepositoryGetSupported, err := server.isFeatureSupported(featureRepositoryGet)
+	featureRepositoryGetSupported, err := si.isFeatureSupported(featureRepositoryGet)
 	if err != nil {
 		return []diag.Diagnostic{
 			{
@@ -144,9 +139,11 @@ func resourceArgoCDRepositoryRead(ctx context.Context, d *schema.ResourceData, m
 		}
 	}
 
+	r := &application.Repository{}
+
 	if featureRepositoryGetSupported {
 		tokenMutexConfiguration.RLock()
-		r, err = c.Get(ctx, &repository.RepoQuery{
+		r, err = si.RepositoryClient.Get(ctx, &repository.RepoQuery{
 			Repo:         d.Id(),
 			ForceRefresh: true,
 		})
@@ -171,7 +168,7 @@ func resourceArgoCDRepositoryRead(ctx context.Context, d *schema.ResourceData, m
 		var rl *application.RepositoryList
 
 		tokenMutexConfiguration.RLock()
-		rl, err = c.ListRepositories(ctx, &repository.RepoQuery{
+		rl, err = si.RepositoryClient.ListRepositories(ctx, &repository.RepoQuery{
 			Repo:         d.Id(),
 			ForceRefresh: true,
 		})
@@ -222,8 +219,8 @@ func resourceArgoCDRepositoryRead(ctx context.Context, d *schema.ResourceData, m
 }
 
 func resourceArgoCDRepositoryUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	server := meta.(*ServerInterface)
-	if err := server.initClients(ctx); err != nil {
+	si := meta.(*ServerInterface)
+	if err := si.initClients(ctx); err != nil {
 		return []diag.Diagnostic{
 			{
 				Severity: diag.Error,
@@ -232,8 +229,6 @@ func resourceArgoCDRepositoryUpdate(ctx context.Context, d *schema.ResourceData,
 			},
 		}
 	}
-
-	c := *server.RepositoryClient
 
 	repo, err := expandRepository(d)
 	if err != nil {
@@ -246,7 +241,7 @@ func resourceArgoCDRepositoryUpdate(ctx context.Context, d *schema.ResourceData,
 		}
 	}
 
-	featureProjectScopedRepositoriesSupported, err := server.isFeatureSupported(featureProjectScopedRepositories)
+	featureProjectScopedRepositoriesSupported, err := si.isFeatureSupported(featureProjectScopedRepositories)
 	if err != nil {
 		return []diag.Diagnostic{
 			{
@@ -270,7 +265,7 @@ func resourceArgoCDRepositoryUpdate(ctx context.Context, d *schema.ResourceData,
 	}
 
 	tokenMutexConfiguration.Lock()
-	r, err := c.UpdateRepository(
+	r, err := si.RepositoryClient.UpdateRepository(
 		ctx,
 		&repository.RepoUpdateRequest{Repo: repo},
 	)
@@ -311,8 +306,8 @@ func resourceArgoCDRepositoryUpdate(ctx context.Context, d *schema.ResourceData,
 }
 
 func resourceArgoCDRepositoryDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	server := meta.(*ServerInterface)
-	if err := server.initClients(ctx); err != nil {
+	si := meta.(*ServerInterface)
+	if err := si.initClients(ctx); err != nil {
 		return []diag.Diagnostic{
 			{
 				Severity: diag.Error,
@@ -322,10 +317,8 @@ func resourceArgoCDRepositoryDelete(ctx context.Context, d *schema.ResourceData,
 		}
 	}
 
-	c := *server.RepositoryClient
-
 	tokenMutexConfiguration.Lock()
-	_, err := c.DeleteRepository(
+	_, err := si.RepositoryClient.DeleteRepository(
 		ctx,
 		&repository.RepoQuery{Repo: d.Id()},
 	)

--- a/argocd/resource_argocd_repository_credentials.go
+++ b/argocd/resource_argocd_repository_credentials.go
@@ -29,8 +29,8 @@ func resourceArgoCDRepositoryCredentials() *schema.Resource {
 }
 
 func resourceArgoCDRepositoryCredentialsCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	server := meta.(*ServerInterface)
-	if err := server.initClients(ctx); err != nil {
+	si := meta.(*ServerInterface)
+	if err := si.initClients(ctx); err != nil {
 		return []diag.Diagnostic{
 			{
 				Severity: diag.Error,
@@ -39,8 +39,6 @@ func resourceArgoCDRepositoryCredentialsCreate(ctx context.Context, d *schema.Re
 			},
 		}
 	}
-
-	c := *server.RepoCredsClient
 
 	repoCreds, err := expandRepositoryCredentials(d)
 	if err != nil {
@@ -54,7 +52,7 @@ func resourceArgoCDRepositoryCredentialsCreate(ctx context.Context, d *schema.Re
 	}
 
 	tokenMutexConfiguration.Lock()
-	rc, err := c.CreateRepositoryCredentials(
+	rc, err := si.RepoCredsClient.CreateRepositoryCredentials(
 		ctx,
 		&repocreds.RepoCredsCreateRequest{
 			Creds:  repoCreds,
@@ -79,8 +77,8 @@ func resourceArgoCDRepositoryCredentialsCreate(ctx context.Context, d *schema.Re
 }
 
 func resourceArgoCDRepositoryCredentialsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	server := meta.(*ServerInterface)
-	if err := server.initClients(ctx); err != nil {
+	si := meta.(*ServerInterface)
+	if err := si.initClients(ctx); err != nil {
 		return []diag.Diagnostic{
 			{
 				Severity: diag.Error,
@@ -90,11 +88,8 @@ func resourceArgoCDRepositoryCredentialsRead(ctx context.Context, d *schema.Reso
 		}
 	}
 
-	c := *server.RepoCredsClient
-	rc := application.RepoCreds{}
-
 	tokenMutexConfiguration.RLock()
-	rcl, err := c.ListRepositoryCredentials(ctx, &repocreds.RepoCredsQuery{
+	rcl, err := si.RepoCredsClient.ListRepositoryCredentials(ctx, &repocreds.RepoCredsQuery{
 		Url: d.Id(),
 	})
 	tokenMutexConfiguration.RUnlock()
@@ -114,6 +109,8 @@ func resourceArgoCDRepositoryCredentialsRead(ctx context.Context, d *schema.Reso
 		return nil
 	}
 
+	rc := application.RepoCreds{}
+
 	for i, _rc := range rcl.Items {
 		if _rc.URL == d.Id() {
 			rc = _rc
@@ -131,8 +128,8 @@ func resourceArgoCDRepositoryCredentialsRead(ctx context.Context, d *schema.Reso
 }
 
 func resourceArgoCDRepositoryCredentialsUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	server := meta.(*ServerInterface)
-	if err := server.initClients(ctx); err != nil {
+	si := meta.(*ServerInterface)
+	if err := si.initClients(ctx); err != nil {
 		return []diag.Diagnostic{
 			{
 				Severity: diag.Error,
@@ -141,8 +138,6 @@ func resourceArgoCDRepositoryCredentialsUpdate(ctx context.Context, d *schema.Re
 			},
 		}
 	}
-
-	c := *server.RepoCredsClient
 
 	repoCreds, err := expandRepositoryCredentials(d)
 	if err != nil {
@@ -156,7 +151,7 @@ func resourceArgoCDRepositoryCredentialsUpdate(ctx context.Context, d *schema.Re
 	}
 
 	tokenMutexConfiguration.Lock()
-	r, err := c.UpdateRepositoryCredentials(
+	r, err := si.RepoCredsClient.UpdateRepositoryCredentials(
 		ctx,
 		&repocreds.RepoCredsUpdateRequest{
 			Creds: repoCreds},
@@ -179,8 +174,8 @@ func resourceArgoCDRepositoryCredentialsUpdate(ctx context.Context, d *schema.Re
 }
 
 func resourceArgoCDRepositoryCredentialsDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	server := meta.(*ServerInterface)
-	if err := server.initClients(ctx); err != nil {
+	si := meta.(*ServerInterface)
+	if err := si.initClients(ctx); err != nil {
 		return []diag.Diagnostic{
 			{
 				Severity: diag.Error,
@@ -190,10 +185,8 @@ func resourceArgoCDRepositoryCredentialsDelete(ctx context.Context, d *schema.Re
 		}
 	}
 
-	c := *server.RepoCredsClient
-
 	tokenMutexConfiguration.Lock()
-	_, err := c.DeleteRepositoryCredentials(
+	_, err := si.RepoCredsClient.DeleteRepositoryCredentials(
 		ctx,
 		&repocreds.RepoCredsDeleteRequest{Url: d.Id()},
 	)


### PR DESCRIPTION
"Cherry picking" this change out of #263 so that that implementation becomes a little cleaner. 

Ultimately the pointers to the `XClient` objects are unnecessary and just end up being dereferenced when we want to use them.