### PR TITLE
Automatically close stale issues

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,4 +1,4 @@
-name: 'Close stale PRs'
+name: 'Close stale Issues/PRs'
 on:
   schedule:
     - cron: '30 12 * * *'
@@ -7,9 +7,13 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v3
+      - uses: actions/stale@v8
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+          days-before-stale: 14
+          days-before-close: 10
+          # Issue settings
+          stale-issue-message: 'This issue is stale because of a lack of response from the original author. Please provide the requested feedback or this will be closed in 10 days.'
+          any-of-issue-labels: 'cannot-reproduce,needs-more-info'
+          # PR Settings
           stale-pr-message: 'This pr is stale because it has been open 14 days with no activity. Remove stale label or comment or this will be closed in 10 days.'
-          days-before-pr-stale: 14
-          days-before-pr-close: 24


### PR DESCRIPTION
Updates settings on `actions/stale` GitHub action to also label issues labelled as `cannot-reproduce` or `needs-more-info` as `Stale` (after 14 days) and to automatically close them 10 days after being labelled as `Stale`.
