### PR TITLE
update semver to v3.2.1, fixes #282

### DIFF
--- a/argocd/resource_argocd_application_test.go
+++ b/argocd/resource_argocd_application_test.go
@@ -2028,8 +2028,8 @@ resource "argocd_application" "multiple_sources" {
   }
 
   spec {
-    project = "default" 
-	
+    project = "default"
+
 	source {
 		repo_url        = "https://helm.elastic.co"
 		chart           = "elasticsearch"
@@ -2069,4 +2069,154 @@ func testAccSkipFeatureIgnoreDiffJQPathExpressions() (bool, error) {
 	}
 
 	return !featureSupported, nil
+}
+
+func testAccArgoCDApplicationHelmVersionRange() string {
+	return `
+resource "argocd_application" "helm_version_range" {
+  metadata {
+    name      = "helm-version-range"
+    namespace = "argocd"
+  }
+
+  spec {
+    project = "default"
+
+	source {
+		repo_url        = "https://helm.elastic.co"
+		chart           = "elasticsearch"
+		target_revision = ">8.0,<9.0"
+	}
+
+    destination {
+      server    = "https://kubernetes.default.svc"
+      namespace = "default"
+    }
+  }
+}`
+}
+
+func TestAccArgoCDApplication_HelmVersionRange(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccArgoCDApplicationHelmVersionRange(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"argocd_application.spec.0.source.0.target_revision",
+						"spec.0.source.0.target_revision",
+						"v8.5.1",
+					),
+				),
+			},
+			{
+				ResourceName:            "argocd_application.spec.0.source.0.target_revision",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"wait", "cascade"},
+			},
+		},
+	})
+}
+
+func testAccArgoCDApplicationHelmVersionGlob() string {
+	return `
+resource "argocd_application" "helm_version_glob" {
+  metadata {
+    name      = "helm-version-glob"
+    namespace = "argocd"
+  }
+
+  spec {
+    project = "default" 
+	
+	source {
+		repo_url        = "https://helm.elastic.co"
+		chart           = "elasticsearch"
+		target_revision = "8.*"
+	}
+
+    destination {
+      server    = "https://kubernetes.default.svc"
+      namespace = "default"
+    }
+  }
+}`
+}
+
+func TestAccArgoCDApplication_HelmVersionGlob(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccArgoCDApplicationHelmVersionGlob(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"argocd_application.spec.0.source.0.target_revision",
+						"spec.0.source.0.target_revision",
+						"v8.5.1",
+					),
+				),
+			},
+			{
+				ResourceName:            "argocd_application.spec.0.source.0.target_revision",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"wait", "cascade"},
+			},
+		},
+	})
+}
+
+func testAccArgoCDApplicationHelmGlob() string {
+	return `
+resource "argocd_application" "helm_glob" {
+  metadata {
+    name      = "helm-glob"
+    namespace = "argocd"
+  }
+
+  spec {
+    project = "default"
+
+	source {
+		repo_url        = "https://helm.elastic.co"
+		chart           = "elasticsearch"
+		target_revision = "*"
+	}
+
+    destination {
+      server    = "https://kubernetes.default.svc"
+      namespace = "default"
+    }
+  }
+}`
+}
+
+func TestAccArgoCDApplication_HelmGlob(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccArgoCDApplicationHelmGlob(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"argocd_application.spec.0.source.0.target_revision",
+						"spec.0.source.0.target_revision",
+						"v8.5.1",
+					),
+				),
+			},
+			{
+				ResourceName:            "argocd_application.spec.0.source.0.target_revision",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"wait", "cascade"},
+			},
+		},
+	})
 }

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/oboukili/terraform-provider-argocd
 go 1.19
 
 require (
-	github.com/Masterminds/semver v1.5.0
+	github.com/Masterminds/semver/v3 v3.2.1 // indirect
 	github.com/apparentlymart/go-cidr v1.1.0 // indirect
 	github.com/argoproj/argo-cd/v2 v2.6.7
 	github.com/argoproj/gitops-engine v0.7.3
@@ -24,6 +24,8 @@ require (
 	modernc.org/mathutil v1.0.0
 )
 
+require github.com/Masterminds/semver v1.5.0
+
 require (
 	cloud.google.com/go v0.99.0 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
@@ -36,7 +38,6 @@ require (
 	github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible // indirect
 	github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
-	github.com/Masterminds/semver/v3 v3.2.0 // indirect
 	github.com/Masterminds/sprig v2.22.0+incompatible // indirect
 	github.com/Masterminds/sprig/v3 v3.2.2 // indirect
 	github.com/Microsoft/go-winio v0.4.17 // indirect

--- a/go.sum
+++ b/go.sum
@@ -85,8 +85,8 @@ github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy86
 github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
-github.com/Masterminds/semver/v3 v3.2.0 h1:3MEsd0SM6jqZojhjLWWeBY+Kcjy9i6MQAeY7YgDP83g=
-github.com/Masterminds/semver/v3 v3.2.0/go.mod h1:qvl/7zhW3nngYb5+80sSMF+FG2BjYrf8m9wsX0PNOMQ=
+github.com/Masterminds/semver/v3 v3.2.1 h1:RN9w6+7QoMeJVGyfmbcgs28Br8cvmnucEXnY0rYXWg0=
+github.com/Masterminds/semver/v3 v3.2.1/go.mod h1:qvl/7zhW3nngYb5+80sSMF+FG2BjYrf8m9wsX0PNOMQ=
 github.com/Masterminds/sprig v2.22.0+incompatible h1:z4yfnGrZ7netVz+0EDJ0Wi+5VZCSYp4Z0m2dk6cEM60=
 github.com/Masterminds/sprig v2.22.0+incompatible/go.mod h1:y6hNFY5UBTIWBxnzTeuNhlNS5hqE0NB0E6fgfo2Br3o=
 github.com/Masterminds/sprig/v3 v3.2.0/go.mod h1:tWhwTbUTndesPNeF0C900vKoq283u6zp4APT9vaF3SI=


### PR DESCRIPTION
This updates semver to use the latest version, rather than the ancient v1.5.0.

I've also added some tests to validate that the provider accepts Helm ranges and globs.