### PR TITLE
Populate `Source` not `Sources` for single source applications

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,7 +48,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        argocd_version: ["v2.5.0", "v2.5.16", "v2.6.0", "v2.6.7", "v2.7.3"]
+        argocd_version: ["v2.5.0", "v2.5.17", "v2.6.0", "v2.6.8", "v2.7.3"]
     steps:
       - name: Check out code
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0

--- a/argocd/resource_argocd_application.go
+++ b/argocd/resource_argocd_application.go
@@ -200,20 +200,23 @@ func resourceArgoCDApplicationCreate(ctx context.Context, d *schema.ResourceData
 				Detail:   err.Error(),
 			},
 		}
-	} else if !featureMultipleApplicationSourcesSupported {
-		if len(spec.Sources) > 1 {
-			return []diag.Diagnostic{
-				{
-					Severity: diag.Error,
-					Summary: fmt.Sprintf(
-						"multiple application sources is only supported from ArgoCD %s onwards",
-						featureVersionConstraintsMap[featureMultipleApplicationSources].String()),
-				},
-			}
-		}
+	}
 
+	l := len(spec.Sources)
+
+	switch {
+	case l == 1:
 		spec.Source = &spec.Sources[0]
 		spec.Sources = nil
+	case l > 1 && !featureMultipleApplicationSourcesSupported:
+		return []diag.Diagnostic{
+			{
+				Severity: diag.Error,
+				Summary: fmt.Sprintf(
+					"multiple application sources is only supported from ArgoCD %s onwards",
+					featureVersionConstraintsMap[featureMultipleApplicationSources].String()),
+			},
+		}
 	}
 
 	featureApplicationHelmSkipCrdsSupported, err := si.isFeatureSupported(featureApplicationHelmSkipCrds)
@@ -473,20 +476,23 @@ func resourceArgoCDApplicationUpdate(ctx context.Context, d *schema.ResourceData
 				Detail:   err.Error(),
 			},
 		}
-	} else if !featureMultipleApplicationSourcesSupported {
-		if len(spec.Sources) > 1 {
-			return []diag.Diagnostic{
-				{
-					Severity: diag.Error,
-					Summary: fmt.Sprintf(
-						"multiple application sources is only supported from ArgoCD %s onwards",
-						featureVersionConstraintsMap[featureMultipleApplicationSources].String()),
-				},
-			}
-		}
+	}
 
+	l := len(spec.Sources)
+
+	switch {
+	case l == 1:
 		spec.Source = &spec.Sources[0]
 		spec.Sources = nil
+	case l > 1 && !featureMultipleApplicationSourcesSupported:
+		return []diag.Diagnostic{
+			{
+				Severity: diag.Error,
+				Summary: fmt.Sprintf(
+					"multiple application sources is only supported from ArgoCD %s onwards",
+					featureVersionConstraintsMap[featureMultipleApplicationSources].String()),
+			},
+		}
 	}
 
 	featureApplicationHelmSkipCrdsSupported, err := si.isFeatureSupported(featureApplicationHelmSkipCrds)

--- a/argocd/structure_application_set.go
+++ b/argocd/structure_application_set.go
@@ -793,13 +793,14 @@ func expandApplicationSetTemplate(temp interface{}, featureMultipleApplicationSo
 			return
 		}
 
-		if !featureMultipleApplicationSourcesSupported {
-			if len(template.Spec.Sources) > 1 {
-				return template, fmt.Errorf("multiple application sources is only supported from ArgoCD %s onwards", featureVersionConstraintsMap[featureMultipleApplicationSources].String())
-			}
+		l := len(template.Spec.Sources)
 
+		switch {
+		case l == 1:
 			template.Spec.Source = &template.Spec.Sources[0]
 			template.Spec.Sources = nil
+		case l > 1 && !featureMultipleApplicationSourcesSupported:
+			return template, fmt.Errorf("multiple application sources is only supported from ArgoCD %s onwards", featureVersionConstraintsMap[featureMultipleApplicationSources].String())
 		}
 	}
 


### PR DESCRIPTION
A few folks are having issues with the `argocd_application` resource since we introduced support for multiple application sources in #262. While one could argue that these issues are not really the fault of the provider, this is still a beta feature within ArgoCD, and we can also mitigate the problems by ensuring that we only make use of `Sources` (when creating/updating applications) for applications that do have multiple sources defined. 

Closes #274 
Closes #288 