### PR TITLE
Refactor error handling

### DIFF
--- a/argocd/features.go
+++ b/argocd/features.go
@@ -30,12 +30,17 @@ const (
 	featureApplicationSetProgressiveSync
 )
 
-var featureVersionConstraintsMap = map[int]*semver.Version{
-	featureExecLogsPolicy:                semver.MustParse("2.4.4"),
-	featureProjectSourceNamespaces:       semver.MustParse("2.5.0"),
-	featureMultipleApplicationSources:    semver.MustParse("2.6.3"), // Whilst the feature was introduced in 2.6.0 there was a bug that affects refresh of applications (and hence `wait` within this provider) that was only fixed in https://github.com/argoproj/argo-cd/pull/12576
-	featureApplicationSet:                semver.MustParse("2.5.0"),
-	featureApplicationSetProgressiveSync: semver.MustParse("2.6.0"),
+type featureConstraint struct {
+	name       string
+	minVersion *semver.Version
+}
+
+var featureConstraintsMap = map[int]featureConstraint{
+	featureExecLogsPolicy:                {"exec/logs RBAC policy", semver.MustParse("2.4.4")},
+	featureProjectSourceNamespaces:       {"project source namespaces", semver.MustParse("2.5.0")},
+	featureMultipleApplicationSources:    {"multiple application sources", semver.MustParse("2.6.3")}, // Whilst the feature was introduced in 2.6.0 there was a bug that affects refresh of applications (and hence `wait` within this provider) that was only fixed in https://github.com/argoproj/argo-cd/pull/12576
+	featureApplicationSet:                {"application sets", semver.MustParse("2.5.0")},
+	featureApplicationSetProgressiveSync: {"progressive sync (`strategy`)", semver.MustParse("2.6.0")},
 }
 
 type ServerInterface struct {
@@ -189,7 +194,7 @@ func (p *ServerInterface) initClients(ctx context.Context) error {
 // Checks that a specific feature is available for the current ArgoCD server version.
 // 'feature' argument must match one of the predefined feature* constants.
 func (p *ServerInterface) isFeatureSupported(feature int) bool {
-	versionConstraint, ok := featureVersionConstraintsMap[feature]
+	fc, ok := featureConstraintsMap[feature]
 
-	return ok && versionConstraint.Compare(p.ServerVersion) != 1
+	return ok && fc.minVersion.Compare(p.ServerVersion) != 1
 }

--- a/argocd/features.go
+++ b/argocd/features.go
@@ -188,15 +188,8 @@ func (p *ServerInterface) initClients(ctx context.Context) error {
 
 // Checks that a specific feature is available for the current ArgoCD server version.
 // 'feature' argument must match one of the predefined feature* constants.
-func (p *ServerInterface) isFeatureSupported(feature int) (bool, error) {
+func (p *ServerInterface) isFeatureSupported(feature int) bool {
 	versionConstraint, ok := featureVersionConstraintsMap[feature]
-	if !ok {
-		return false, fmt.Errorf("feature constraint is not handled by the provider")
-	}
 
-	if i := versionConstraint.Compare(p.ServerVersion); i == 1 {
-		return false, nil
-	}
-
-	return true, nil
+	return ok && versionConstraint.Compare(p.ServerVersion) != 1
 }

--- a/argocd/features.go
+++ b/argocd/features.go
@@ -23,16 +23,7 @@ import (
 )
 
 const (
-	featureApplicationLevelSyncOptions = iota
-	featureIgnoreDiffJQPathExpressions
-	featureRepositoryGet
-	featureTokenIDs
-	featureProjectScopedClusters
-	featureProjectScopedRepositories
-	featureClusterMetadata
-	featureRepositoryCertificates
-	featureApplicationHelmSkipCrds
-	featureExecLogsPolicy
+	featureExecLogsPolicy = iota
 	featureProjectSourceNamespaces
 	featureMultipleApplicationSources
 	featureApplicationSet
@@ -40,15 +31,6 @@ const (
 )
 
 var featureVersionConstraintsMap = map[int]*semver.Version{
-	featureApplicationLevelSyncOptions:   semver.MustParse("1.5.0"),
-	featureIgnoreDiffJQPathExpressions:   semver.MustParse("2.1.0"),
-	featureRepositoryGet:                 semver.MustParse("1.6.0"),
-	featureTokenIDs:                      semver.MustParse("1.5.3"),
-	featureProjectScopedClusters:         semver.MustParse("2.2.0"),
-	featureProjectScopedRepositories:     semver.MustParse("2.2.0"),
-	featureClusterMetadata:               semver.MustParse("2.2.0"),
-	featureRepositoryCertificates:        semver.MustParse("1.2.0"),
-	featureApplicationHelmSkipCrds:       semver.MustParse("2.3.0"),
 	featureExecLogsPolicy:                semver.MustParse("2.4.4"),
 	featureProjectSourceNamespaces:       semver.MustParse("2.5.0"),
 	featureMultipleApplicationSources:    semver.MustParse("2.6.3"), // Whilst the feature was introduced in 2.6.0 there was a bug that affects refresh of applications (and hence `wait` within this provider) that was only fixed in https://github.com/argoproj/argo-cd/pull/12576

--- a/argocd/features_test.go
+++ b/argocd/features_test.go
@@ -73,23 +73,23 @@ func TestServerInterface_isFeatureSupported(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name:    "featureTokenID-1.5.3",
-			si:      serverInterfaceTestData(t, "1.5.3", semverEquals),
-			args:    args{feature: featureTokenIDs},
+			name:    "featureExecLogsPolicy-2.7.2",
+			si:      serverInterfaceTestData(t, "2.7.2", semverEquals),
+			args:    args{feature: featureExecLogsPolicy},
 			want:    true,
 			wantErr: false,
 		},
 		{
-			name:    "featureTokenID-1.5.3+",
-			si:      serverInterfaceTestData(t, "1.5.3", semverGreater),
-			args:    args{feature: featureTokenIDs},
+			name:    "featureExecLogsPolicy-2.7.2+",
+			si:      serverInterfaceTestData(t, "2.7.2", semverGreater),
+			args:    args{feature: featureExecLogsPolicy},
 			want:    true,
 			wantErr: false,
 		},
 		{
-			name:    "featureTokenID-1.5.3-",
-			si:      serverInterfaceTestData(t, "1.5.3", semverLess),
-			args:    args{feature: featureTokenIDs},
+			name:    "featureExecLogsPolicy-2.7.2-",
+			si:      serverInterfaceTestData(t, "2.7.2", semverLess),
+			args:    args{feature: featureExecLogsPolicy},
 			want:    false,
 			wantErr: false,
 		},

--- a/argocd/features_test.go
+++ b/argocd/features_test.go
@@ -66,32 +66,28 @@ func TestServerInterface_isFeatureSupported(t *testing.T) {
 	}
 
 	tests := []struct {
-		name    string
-		si      *ServerInterface
-		args    args
-		want    bool
-		wantErr bool
+		name string
+		si   *ServerInterface
+		args args
+		want bool
 	}{
 		{
-			name:    "featureExecLogsPolicy-2.7.2",
-			si:      serverInterfaceTestData(t, "2.7.2", semverEquals),
-			args:    args{feature: featureExecLogsPolicy},
-			want:    true,
-			wantErr: false,
+			name: "featureExecLogsPolicy-2.7.2",
+			si:   serverInterfaceTestData(t, "2.7.2", semverEquals),
+			args: args{feature: featureExecLogsPolicy},
+			want: true,
 		},
 		{
-			name:    "featureExecLogsPolicy-2.7.2+",
-			si:      serverInterfaceTestData(t, "2.7.2", semverGreater),
-			args:    args{feature: featureExecLogsPolicy},
-			want:    true,
-			wantErr: false,
+			name: "featureExecLogsPolicy-2.7.2+",
+			si:   serverInterfaceTestData(t, "2.7.2", semverGreater),
+			args: args{feature: featureExecLogsPolicy},
+			want: true,
 		},
 		{
-			name:    "featureExecLogsPolicy-2.7.2-",
-			si:      serverInterfaceTestData(t, "2.7.2", semverLess),
-			args:    args{feature: featureExecLogsPolicy},
-			want:    false,
-			wantErr: false,
+			name: "featureExecLogsPolicy-2.7.2-",
+			si:   serverInterfaceTestData(t, "2.7.2", semverLess),
+			args: args{feature: featureExecLogsPolicy},
+			want: false,
 		},
 	}
 
@@ -101,14 +97,7 @@ func TestServerInterface_isFeatureSupported(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			got, err := tt.si.isFeatureSupported(tt.args.feature)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("isFeatureSupported() error = %v, wantErr %v",
-					err,
-					tt.wantErr,
-				)
-				return
-			}
+			got := tt.si.isFeatureSupported(tt.args.feature)
 
 			if got != tt.want {
 				t.Errorf("isFeatureSupported() got = %v, want %v, version %s",

--- a/argocd/provider_test.go
+++ b/argocd/provider_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/oboukili/terraform-provider-argocd/internal/features"
 )
 
 var testAccProviders map[string]func() (*schema.Provider, error)
@@ -68,7 +69,7 @@ func testAccPreCheck(t *testing.T) {
 }
 
 // Skip test if feature is not supported
-func testAccPreCheckFeatureSupported(t *testing.T, feature int) {
+func testAccPreCheckFeatureSupported(t *testing.T, feature features.Feature) {
 	v := os.Getenv("ARGOCD_VERSION")
 	if v == "" {
 		t.Skip("ARGOCD_VERSION must be set set for feature supported acceptance tests")
@@ -79,12 +80,12 @@ func testAccPreCheckFeatureSupported(t *testing.T, feature int) {
 		t.Fatalf("could not parse ARGOCD_VERSION as semantic version: %s", v)
 	}
 
-	fc, ok := featureConstraintsMap[feature]
+	fc, ok := features.ConstraintsMap[feature]
 	if !ok {
 		t.Fatal("feature constraint is not handled by the provider")
 	}
 
-	if i := fc.minVersion.Compare(serverVersion); i == 1 {
+	if i := fc.MinVersion.Compare(serverVersion); i == 1 {
 		t.Skipf("version %s does not support feature", v)
 	}
 }

--- a/argocd/provider_test.go
+++ b/argocd/provider_test.go
@@ -79,12 +79,12 @@ func testAccPreCheckFeatureSupported(t *testing.T, feature int) {
 		t.Fatalf("could not parse ARGOCD_VERSION as semantic version: %s", v)
 	}
 
-	versionConstraint, ok := featureVersionConstraintsMap[feature]
+	fc, ok := featureConstraintsMap[feature]
 	if !ok {
 		t.Fatal("feature constraint is not handled by the provider")
 	}
 
-	if i := versionConstraint.Compare(serverVersion); i == 1 {
+	if i := fc.minVersion.Compare(serverVersion); i == 1 {
 		t.Skipf("version %s does not support feature", v)
 	}
 }

--- a/argocd/provider_test.go
+++ b/argocd/provider_test.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/Masterminds/semver"
+	"github.com/Masterminds/semver/v3"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/argocd/provider_test.go
+++ b/argocd/provider_test.go
@@ -90,23 +90,24 @@ func testAccPreCheckFeatureSupported(t *testing.T, feature int) {
 }
 
 // Skip test if feature is supported
-func testAccPreCheckFeatureNotSupported(t *testing.T, feature int) {
-	v := os.Getenv("ARGOCD_VERSION")
-	if v == "" {
-		t.Skip("ARGOCD_VERSION must be set set for feature supported acceptance tests")
-	}
+// Note: unused at present but left in the code in case it is needed again in future
+// func testAccPreCheckFeatureNotSupported(t *testing.T, feature int) {
+// 	v := os.Getenv("ARGOCD_VERSION")
+// 	if v == "" {
+// 		t.Skip("ARGOCD_VERSION must be set set for feature supported acceptance tests")
+// 	}
 
-	serverVersion, err := semver.NewVersion(v)
-	if err != nil {
-		t.Fatalf("could not parse ARGOCD_VERSION as semantic version: %s", v)
-	}
+// 	serverVersion, err := semver.NewVersion(v)
+// 	if err != nil {
+// 		t.Fatalf("could not parse ARGOCD_VERSION as semantic version: %s", v)
+// 	}
 
-	versionConstraint, ok := featureVersionConstraintsMap[feature]
-	if !ok {
-		t.Fatal("feature constraint is not handled by the provider")
-	}
+// 	versionConstraint, ok := featureVersionConstraintsMap[feature]
+// 	if !ok {
+// 		t.Fatal("feature constraint is not handled by the provider")
+// 	}
 
-	if i := versionConstraint.Compare(serverVersion); i != 1 {
-		t.Skipf("not running test if feature is already supported (%s)", v)
-	}
-}
+// 	if i := versionConstraint.Compare(serverVersion); i != 1 {
+// 		t.Skipf("not running test if feature is already supported (%s)", v)
+// 	}
+// }

--- a/argocd/resource_argocd_account_token.go
+++ b/argocd/resource_argocd_account_token.go
@@ -222,13 +222,7 @@ func resourceArgoCDAccountTokenCreate(ctx context.Context, d *schema.ResourceDat
 	tokenMutexSecrets.Unlock()
 
 	if err != nil {
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary:  fmt.Sprintf("token for account %s could not be created", accountName),
-				Detail:   err.Error(),
-			},
-		}
+		return argoCDAPIError("create", "token for account", accountName, err)
 	}
 
 	token, err := jwt.ParseString(resp.GetToken())
@@ -335,13 +329,7 @@ func resourceArgoCDAccountTokenRead(ctx context.Context, d *schema.ResourceData,
 			d.SetId("")
 			return nil
 		} else {
-			return []diag.Diagnostic{
-				{
-					Severity: diag.Error,
-					Summary:  fmt.Sprintf("account %s could not be read", accountName),
-					Detail:   err.Error(),
-				},
-			}
+			return argoCDAPIError("read", "account", accountName, err)
 		}
 	}
 
@@ -432,13 +420,7 @@ func resourceArgoCDAccountTokenDelete(ctx context.Context, d *schema.ResourceDat
 	tokenMutexSecrets.Unlock()
 
 	if err != nil && !strings.Contains(err.Error(), "NotFound") {
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary:  fmt.Sprintf("token for account %s could not be deleted", accountName),
-				Detail:   err.Error(),
-			},
-		}
+		return argoCDAPIError("delete", "token for account", accountName, err)
 	}
 
 	d.SetId("")

--- a/argocd/resource_argocd_account_token.go
+++ b/argocd/resource_argocd_account_token.go
@@ -145,24 +145,12 @@ func resourceArgoCDAccountToken() *schema.Resource {
 func resourceArgoCDAccountTokenCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	si := meta.(*ServerInterface)
 	if err := si.initClients(ctx); err != nil {
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary:  "failed to init clients",
-				Detail:   err.Error(),
-			},
-		}
+		return errorToDiagnostics("failed to init clients", err)
 	}
 
 	accountName, err := getAccount(ctx, si, d)
 	if err != nil {
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary:  "failed to get account",
-				Detail:   err.Error(),
-			},
-		}
+		return errorToDiagnostics("failed to get account", err)
 	}
 
 	opts := &account.CreateTokenRequest{
@@ -177,13 +165,7 @@ func resourceArgoCDAccountTokenCreate(ctx context.Context, d *schema.ResourceDat
 		expiresInDuration, err := time.ParseDuration(ei)
 
 		if err != nil {
-			return []diag.Diagnostic{
-				{
-					Severity: diag.Error,
-					Summary:  fmt.Sprintf("token expiration duration (%s) for account %s could not be parsed", ei, accountName),
-					Detail:   err.Error(),
-				},
-			}
+			return errorToDiagnostics(fmt.Sprintf("token expiration duration (%s) for account %s could not be parsed", ei, accountName), err)
 		}
 
 		expiresIn = int64(expiresInDuration.Seconds())
@@ -196,13 +178,7 @@ func resourceArgoCDAccountTokenCreate(ctx context.Context, d *schema.ResourceDat
 		renewBeforeDuration, err := time.ParseDuration(rb)
 
 		if err != nil {
-			return []diag.Diagnostic{
-				{
-					Severity: diag.Error,
-					Summary:  fmt.Sprintf("token renewal duration (%s) for account %s could not be parsed", rb, accountName),
-					Detail:   err.Error(),
-				},
-			}
+			return errorToDiagnostics(fmt.Sprintf("token renewal duration (%s) for account %s could not be parsed", rb, accountName), err)
 		}
 
 		renewBefore := int64(renewBeforeDuration.Seconds())
@@ -227,24 +203,12 @@ func resourceArgoCDAccountTokenCreate(ctx context.Context, d *schema.ResourceDat
 
 	token, err := jwt.ParseString(resp.GetToken())
 	if err != nil {
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary:  fmt.Sprintf("token for account %s is not a valid jwt", accountName),
-				Detail:   err.Error(),
-			},
-		}
+		return errorToDiagnostics(fmt.Sprintf("token for account %s is not a valid jwt", accountName), err)
 	}
 
 	var claims jwt.StandardClaims
 	if err = json.Unmarshal(token.RawClaims(), &claims); err != nil {
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary:  fmt.Sprintf("token claims for account %s could not be parsed", accountName),
-				Detail:   err.Error(),
-			},
-		}
+		return errorToDiagnostics(fmt.Sprintf("token claims for account %s could not be parsed", accountName), err)
 	}
 
 	if expiresInOk {
@@ -258,35 +222,17 @@ func resourceArgoCDAccountTokenCreate(ctx context.Context, d *schema.ResourceDat
 		} else {
 			err = d.Set("expires_at", convertInt64ToString(claims.ExpiresAt.Unix()))
 			if err != nil {
-				return []diag.Diagnostic{
-					{
-						Severity: diag.Error,
-						Summary:  fmt.Sprintf("token claims expiration date for account %s could not be persisted to state", accountName),
-						Detail:   err.Error(),
-					},
-				}
+				return errorToDiagnostics(fmt.Sprintf("token claims expiration date for account %s could not be persisted to state", accountName), err)
 			}
 		}
 	}
 
 	if err = d.Set("issued_at", convertInt64ToString(claims.IssuedAt.Unix())); err != nil {
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary:  fmt.Sprintf("token claims issue date for account %s could not be persisted to state", accountName),
-				Detail:   err.Error(),
-			},
-		}
+		return errorToDiagnostics(fmt.Sprintf("token claims issue date for account %s could not be persisted to state", accountName), err)
 	}
 
 	if err := d.Set("jwt", token.String()); err != nil {
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary:  fmt.Sprintf("token for account %s could not be persisted to state", accountName),
-				Detail:   err.Error(),
-			},
-		}
+		return errorToDiagnostics(fmt.Sprintf("token for account %s could not be persisted to state", accountName), err)
 	}
 
 	d.SetId(claims.ID)
@@ -297,24 +243,12 @@ func resourceArgoCDAccountTokenCreate(ctx context.Context, d *schema.ResourceDat
 func resourceArgoCDAccountTokenRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	si := meta.(*ServerInterface)
 	if err := si.initClients(ctx); err != nil {
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary:  "failed to init clients",
-				Detail:   err.Error(),
-			},
-		}
+		return errorToDiagnostics("failed to init clients", err)
 	}
 
 	accountName, err := getAccount(ctx, si, d)
 	if err != nil {
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary:  "failed to get account",
-				Detail:   err.Error(),
-			},
-		}
+		return errorToDiagnostics("failed to get account", err)
 	}
 
 	tokenMutexConfiguration.RLock() // Yes, this is a different mutex - accounts are stored in `argocd-cm` whereas tokens are stored in `argocd-secret`
@@ -347,13 +281,7 @@ func resourceArgoCDAccountTokenUpdate(ctx context.Context, d *schema.ResourceDat
 		expiresInDuration, err := time.ParseDuration(ei)
 
 		if err != nil {
-			return []diag.Diagnostic{
-				{
-					Severity: diag.Error,
-					Summary:  fmt.Sprintf("token expiration duration (%s) for account %s could not be parsed", ei, accountName),
-					Detail:   err.Error(),
-				},
-			}
+			return errorToDiagnostics(fmt.Sprintf("token expiration duration (%s) for account %s could not be parsed", ei, accountName), err)
 		}
 
 		expiresIn = int64(expiresInDuration.Seconds())
@@ -365,13 +293,7 @@ func resourceArgoCDAccountTokenUpdate(ctx context.Context, d *schema.ResourceDat
 		renewBeforeDuration, err := time.ParseDuration(rb)
 
 		if err != nil {
-			return []diag.Diagnostic{
-				{
-					Severity: diag.Error,
-					Summary:  fmt.Sprintf("token renewal duration (%s) for account %s could not be parsed", rb, accountName),
-					Detail:   err.Error(),
-				},
-			}
+			return errorToDiagnostics(fmt.Sprintf("token renewal duration (%s) for account %s could not be parsed", rb, accountName), err)
 		}
 
 		renewBefore := int64(renewBeforeDuration.Seconds())
@@ -380,7 +302,6 @@ func resourceArgoCDAccountTokenUpdate(ctx context.Context, d *schema.ResourceDat
 				{
 					Severity: diag.Error,
 					Summary:  fmt.Sprintf("renew_before (%d) cannot be greater than expires_in (%d) for account %s", renewBefore, expiresIn, accountName),
-					Detail:   err.Error(),
 				},
 			}
 		}
@@ -392,24 +313,12 @@ func resourceArgoCDAccountTokenUpdate(ctx context.Context, d *schema.ResourceDat
 func resourceArgoCDAccountTokenDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	si := meta.(*ServerInterface)
 	if err := si.initClients(ctx); err != nil {
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary:  "failed to init clients",
-				Detail:   err.Error(),
-			},
-		}
+		return errorToDiagnostics("failed to init clients", err)
 	}
 
 	accountName, err := getAccount(ctx, si, d)
 	if err != nil {
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary:  "failed to get account",
-				Detail:   err.Error(),
-			},
-		}
+		return errorToDiagnostics("failed to get account", err)
 	}
 
 	tokenMutexSecrets.Lock()

--- a/argocd/resource_argocd_application.go
+++ b/argocd/resource_argocd_application.go
@@ -101,13 +101,7 @@ func resourceArgoCDApplicationCreate(ctx context.Context, d *schema.ResourceData
 		AppNamespace: &objectMeta.Namespace,
 	})
 	if err != nil && !strings.Contains(err.Error(), "NotFound") {
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary:  fmt.Sprintf("failed to get application %s", objectMeta.Name),
-				Detail:   err.Error(),
-			},
-		}
+		return argoCDAPIError("list", "existing applications", objectMeta.Name, err)
 	}
 
 	if apps != nil {
@@ -154,13 +148,7 @@ func resourceArgoCDApplicationCreate(ctx context.Context, d *schema.ResourceData
 		},
 	})
 	if err != nil {
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary:  fmt.Sprintf("application %s could not be created", objectMeta.Name),
-				Detail:   err.Error(),
-			},
-		}
+		return argoCDAPIError("create", "application", objectMeta.Name, err)
 	} else if app == nil {
 		return []diag.Diagnostic{
 			{
@@ -235,13 +223,7 @@ func resourceArgoCDApplicationRead(ctx context.Context, d *schema.ResourceData, 
 			return diag.Diagnostics{}
 		}
 
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary:  fmt.Sprintf("failed to get application %s", appName),
-				Detail:   err.Error(),
-			},
-		}
+		return argoCDAPIError("read", "application", appName, err)
 	}
 
 	l := len(apps.Items)
@@ -355,13 +337,7 @@ func resourceArgoCDApplicationUpdate(ctx context.Context, d *schema.ResourceData
 			},
 		},
 	}); err != nil {
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary:  fmt.Sprintf("application %s could not be updated", *appQuery.Name),
-				Detail:   err.Error(),
-			},
-		}
+		return argoCDAPIError("update", "application", objectMeta.Name, err)
 	}
 
 	if wait, _ok := d.GetOk("wait"); _ok && wait.(bool) {
@@ -424,13 +400,7 @@ func resourceArgoCDApplicationDelete(ctx context.Context, d *schema.ResourceData
 		Cascade:      &cascade,
 		AppNamespace: &namespace,
 	}); err != nil && !strings.Contains(err.Error(), "NotFound") {
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary:  fmt.Sprintf("application %s could not be deleted", appName),
-				Detail:   err.Error(),
-			},
-		}
+		return argoCDAPIError("delete", "application", appName, err)
 	}
 
 	if wait, ok := d.GetOk("wait"); ok && wait.(bool) {

--- a/argocd/resource_argocd_application.go
+++ b/argocd/resource_argocd_application.go
@@ -133,64 +133,6 @@ func resourceArgoCDApplicationCreate(ctx context.Context, d *schema.ResourceData
 		}
 	}
 
-	featureApplicationLevelSyncOptionsSupported, err := si.isFeatureSupported(featureApplicationLevelSyncOptions)
-	if err != nil {
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary:  "feature not supported",
-				Detail:   err.Error(),
-			},
-		}
-	}
-
-	if !featureApplicationLevelSyncOptionsSupported &&
-		spec.SyncPolicy != nil &&
-		spec.SyncPolicy.SyncOptions != nil {
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary: fmt.Sprintf(
-					"application-level sync_options is only supported from ArgoCD %s onwards",
-					featureVersionConstraintsMap[featureApplicationLevelSyncOptions].String()),
-				Detail: err.Error(),
-			},
-		}
-	}
-
-	featureIgnoreDiffJQPathExpressionsSupported, err := si.isFeatureSupported(featureIgnoreDiffJQPathExpressions)
-	if err != nil {
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary:  "feature not supported",
-				Detail:   err.Error(),
-			},
-		}
-	}
-
-	hasJQPathExpressions := false
-
-	if spec.IgnoreDifferences != nil {
-		for _, id := range spec.IgnoreDifferences {
-			if id.JQPathExpressions != nil {
-				hasJQPathExpressions = true
-			}
-		}
-	}
-
-	if !featureIgnoreDiffJQPathExpressionsSupported && hasJQPathExpressions {
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary: fmt.Sprintf(
-					"jq path expressions are only supported from ArgoCD %s onwards",
-					featureVersionConstraintsMap[featureIgnoreDiffJQPathExpressions].String()),
-				Detail: err.Error(),
-			},
-		}
-	}
-
 	featureMultipleApplicationSourcesSupported, err := si.isFeatureSupported(featureMultipleApplicationSources)
 	if err != nil {
 		return []diag.Diagnostic{
@@ -216,31 +158,6 @@ func resourceArgoCDApplicationCreate(ctx context.Context, d *schema.ResourceData
 					"multiple application sources is only supported from ArgoCD %s onwards",
 					featureVersionConstraintsMap[featureMultipleApplicationSources].String()),
 			},
-		}
-	}
-
-	featureApplicationHelmSkipCrdsSupported, err := si.isFeatureSupported(featureApplicationHelmSkipCrds)
-	if err != nil {
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary:  "feature not supported",
-				Detail:   err.Error(),
-			},
-		}
-	}
-
-	if !featureApplicationHelmSkipCrdsSupported {
-		_, skipCrdsOk := d.GetOk("spec.0.source.0.helm.0.skip_crds")
-		if skipCrdsOk {
-			return []diag.Diagnostic{
-				{
-					Severity: diag.Error,
-					Summary: fmt.Sprintf(
-						"application helm skip_crds is only supported from ArgoCD %s onwards",
-						featureVersionConstraintsMap[featureApplicationHelmSkipCrds].String()),
-				},
-			}
 		}
 	}
 
@@ -409,64 +326,6 @@ func resourceArgoCDApplicationUpdate(ctx context.Context, d *schema.ResourceData
 		}
 	}
 
-	featureApplicationLevelSyncOptionsSupported, err := si.isFeatureSupported(featureApplicationLevelSyncOptions)
-	if err != nil {
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary:  "Feature not supported",
-				Detail:   err.Error(),
-			},
-		}
-	}
-
-	if !featureApplicationLevelSyncOptionsSupported &&
-		spec.SyncPolicy != nil &&
-		spec.SyncPolicy.SyncOptions != nil {
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary: fmt.Sprintf(
-					"application-level sync_options is only supported from ArgoCD %s onwards",
-					featureVersionConstraintsMap[featureApplicationLevelSyncOptions].String()),
-				Detail: err.Error(),
-			},
-		}
-	}
-
-	featureIgnoreDiffJQPathExpressionsSupported, err := si.isFeatureSupported(featureIgnoreDiffJQPathExpressions)
-	if err != nil {
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary:  "feature not supported",
-				Detail:   err.Error(),
-			},
-		}
-	}
-
-	hasJQPathExpressions := false
-
-	if spec.IgnoreDifferences != nil {
-		for _, id := range spec.IgnoreDifferences {
-			if id.JQPathExpressions != nil {
-				hasJQPathExpressions = true
-			}
-		}
-	}
-
-	if !featureIgnoreDiffJQPathExpressionsSupported && hasJQPathExpressions {
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary: fmt.Sprintf(
-					"jq path expressions are only supported from ArgoCD %s onwards",
-					featureVersionConstraintsMap[featureIgnoreDiffJQPathExpressions].String()),
-				Detail: err.Error(),
-			},
-		}
-	}
-
 	featureMultipleApplicationSourcesSupported, err := si.isFeatureSupported(featureMultipleApplicationSources)
 	if err != nil {
 		return []diag.Diagnostic{
@@ -492,29 +351,6 @@ func resourceArgoCDApplicationUpdate(ctx context.Context, d *schema.ResourceData
 					"multiple application sources is only supported from ArgoCD %s onwards",
 					featureVersionConstraintsMap[featureMultipleApplicationSources].String()),
 			},
-		}
-	}
-
-	featureApplicationHelmSkipCrdsSupported, err := si.isFeatureSupported(featureApplicationHelmSkipCrds)
-	if err != nil {
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary:  "feature not supported",
-				Detail:   err.Error(),
-			},
-		}
-	} else if !featureApplicationHelmSkipCrdsSupported {
-		_, skipCrdsOk := d.GetOk("spec.0.source.0.helm.0.skip_crds")
-		if skipCrdsOk {
-			return []diag.Diagnostic{
-				{
-					Severity: diag.Error,
-					Summary: fmt.Sprintf(
-						"application helm skip_crds is only supported from ArgoCD %s onwards",
-						featureVersionConstraintsMap[featureApplicationHelmSkipCrds].String()),
-				},
-			}
 		}
 	}
 

--- a/argocd/resource_argocd_application.go
+++ b/argocd/resource_argocd_application.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/oboukili/terraform-provider-argocd/internal/features"
 )
 
 func resourceArgoCDApplication() *schema.Resource {
@@ -121,8 +122,8 @@ func resourceArgoCDApplicationCreate(ctx context.Context, d *schema.ResourceData
 	case l == 1:
 		spec.Source = &spec.Sources[0]
 		spec.Sources = nil
-	case l > 1 && !si.isFeatureSupported(featureMultipleApplicationSources):
-		return featureNotSupported(featureMultipleApplicationSources)
+	case l > 1 && !si.isFeatureSupported(features.MultipleApplicationSources):
+		return featureNotSupported(features.MultipleApplicationSources)
 	}
 
 	app, err := si.ApplicationClient.Create(ctx, &applicationClient.ApplicationCreateRequest{
@@ -254,8 +255,8 @@ func resourceArgoCDApplicationUpdate(ctx context.Context, d *schema.ResourceData
 	case l == 1:
 		spec.Source = &spec.Sources[0]
 		spec.Sources = nil
-	case l > 1 && !si.isFeatureSupported(featureMultipleApplicationSources):
-		return featureNotSupported(featureMultipleApplicationSources)
+	case l > 1 && !si.isFeatureSupported(features.MultipleApplicationSources):
+		return featureNotSupported(features.MultipleApplicationSources)
 	}
 
 	apps, err := si.ApplicationClient.List(ctx, appQuery)

--- a/argocd/resource_argocd_application.go
+++ b/argocd/resource_argocd_application.go
@@ -133,24 +133,13 @@ func resourceArgoCDApplicationCreate(ctx context.Context, d *schema.ResourceData
 		}
 	}
 
-	featureMultipleApplicationSourcesSupported, err := si.isFeatureSupported(featureMultipleApplicationSources)
-	if err != nil {
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary:  "feature not supported",
-				Detail:   err.Error(),
-			},
-		}
-	}
-
 	l := len(spec.Sources)
 
 	switch {
 	case l == 1:
 		spec.Source = &spec.Sources[0]
 		spec.Sources = nil
-	case l > 1 && !featureMultipleApplicationSourcesSupported:
+	case l > 1 && !!si.isFeatureSupported(featureMultipleApplicationSources):
 		return []diag.Diagnostic{
 			{
 				Severity: diag.Error,
@@ -326,24 +315,13 @@ func resourceArgoCDApplicationUpdate(ctx context.Context, d *schema.ResourceData
 		}
 	}
 
-	featureMultipleApplicationSourcesSupported, err := si.isFeatureSupported(featureMultipleApplicationSources)
-	if err != nil {
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary:  "feature not supported",
-				Detail:   err.Error(),
-			},
-		}
-	}
-
 	l := len(spec.Sources)
 
 	switch {
 	case l == 1:
 		spec.Source = &spec.Sources[0]
 		spec.Sources = nil
-	case l > 1 && !featureMultipleApplicationSourcesSupported:
+	case l > 1 && !!si.isFeatureSupported(featureMultipleApplicationSources):
 		return []diag.Diagnostic{
 			{
 				Severity: diag.Error,

--- a/argocd/resource_argocd_application.go
+++ b/argocd/resource_argocd_application.go
@@ -139,15 +139,8 @@ func resourceArgoCDApplicationCreate(ctx context.Context, d *schema.ResourceData
 	case l == 1:
 		spec.Source = &spec.Sources[0]
 		spec.Sources = nil
-	case l > 1 && !!si.isFeatureSupported(featureMultipleApplicationSources):
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary: fmt.Sprintf(
-					"multiple application sources is only supported from ArgoCD %s onwards",
-					featureVersionConstraintsMap[featureMultipleApplicationSources].String()),
-			},
-		}
+	case l > 1 && !si.isFeatureSupported(featureMultipleApplicationSources):
+		return featureNotSupported(featureMultipleApplicationSources)
 	}
 
 	app, err := si.ApplicationClient.Create(ctx, &applicationClient.ApplicationCreateRequest{
@@ -321,15 +314,8 @@ func resourceArgoCDApplicationUpdate(ctx context.Context, d *schema.ResourceData
 	case l == 1:
 		spec.Source = &spec.Sources[0]
 		spec.Sources = nil
-	case l > 1 && !!si.isFeatureSupported(featureMultipleApplicationSources):
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary: fmt.Sprintf(
-					"multiple application sources is only supported from ArgoCD %s onwards",
-					featureVersionConstraintsMap[featureMultipleApplicationSources].String()),
-			},
-		}
+	case l > 1 && !si.isFeatureSupported(featureMultipleApplicationSources):
+		return featureNotSupported(featureMultipleApplicationSources)
 	}
 
 	apps, err := si.ApplicationClient.List(ctx, appQuery)

--- a/argocd/resource_argocd_application_set.go
+++ b/argocd/resource_argocd_application_set.go
@@ -42,14 +42,7 @@ func resourceArgoCDApplicationSetCreate(ctx context.Context, d *schema.ResourceD
 	}
 
 	if !si.isFeatureSupported(featureApplicationSet) {
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary: fmt.Sprintf(
-					"application set is only supported from ArgoCD %s onwards",
-					featureVersionConstraintsMap[featureApplicationSet].String()),
-			},
-		}
+		return featureNotSupported(featureApplicationSet)
 	}
 
 	objectMeta, spec, err := expandApplicationSet(d, si.isFeatureSupported(featureMultipleApplicationSources))
@@ -64,15 +57,7 @@ func resourceArgoCDApplicationSetCreate(ctx context.Context, d *schema.ResourceD
 	}
 
 	if !si.isFeatureSupported(featureApplicationSetProgressiveSync) && spec.Strategy != nil {
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary: fmt.Sprintf(
-					"progressive sync (`strategy`) is only supported from ArgoCD %s onwards",
-					featureVersionConstraintsMap[featureApplicationSetProgressiveSync].String()),
-				Detail: err.Error(),
-			},
-		}
+		return featureNotSupported(featureApplicationSetProgressiveSync)
 	}
 
 	as, err := si.ApplicationSetClient.Create(ctx, &applicationset.ApplicationSetCreateRequest{
@@ -168,14 +153,7 @@ func resourceArgoCDApplicationSetUpdate(ctx context.Context, d *schema.ResourceD
 	}
 
 	if !si.isFeatureSupported(featureApplicationSet) {
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary: fmt.Sprintf(
-					"application set is only supported from ArgoCD %s onwards",
-					featureVersionConstraintsMap[featureApplicationSet].String()),
-			},
-		}
+		return featureNotSupported(featureApplicationSet)
 	}
 
 	if !d.HasChanges("metadata", "spec") {
@@ -194,15 +172,7 @@ func resourceArgoCDApplicationSetUpdate(ctx context.Context, d *schema.ResourceD
 	}
 
 	if !si.isFeatureSupported(featureApplicationSetProgressiveSync) && spec.Strategy != nil {
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary: fmt.Sprintf(
-					"progressive sync (`strategy`) is only supported from ArgoCD %s onwards",
-					featureVersionConstraintsMap[featureApplicationSetProgressiveSync].String()),
-				Detail: err.Error(),
-			},
-		}
+		return featureNotSupported(featureApplicationSetProgressiveSync)
 	}
 
 	_, err = si.ApplicationSetClient.Create(ctx, &applicationset.ApplicationSetCreateRequest{

--- a/argocd/resource_argocd_application_set.go
+++ b/argocd/resource_argocd_application_set.go
@@ -32,13 +32,7 @@ func resourceArgoCDApplicationSet() *schema.Resource {
 func resourceArgoCDApplicationSetCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	si := meta.(*ServerInterface)
 	if err := si.initClients(ctx); err != nil {
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary:  "failed to init clients",
-				Detail:   err.Error(),
-			},
-		}
+		return errorToDiagnostics("failed to init clients", err)
 	}
 
 	if !si.isFeatureSupported(featureApplicationSet) {
@@ -47,13 +41,7 @@ func resourceArgoCDApplicationSetCreate(ctx context.Context, d *schema.ResourceD
 
 	objectMeta, spec, err := expandApplicationSet(d, si.isFeatureSupported(featureMultipleApplicationSources))
 	if err != nil {
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary:  fmt.Sprintf("application set %s could not be created", d.Id()),
-				Detail:   err.Error(),
-			},
-		}
+		return errorToDiagnostics("failed to expand application set", err)
 	}
 
 	if !si.isFeatureSupported(featureApplicationSetProgressiveSync) && spec.Strategy != nil {
@@ -89,13 +77,7 @@ func resourceArgoCDApplicationSetCreate(ctx context.Context, d *schema.ResourceD
 func resourceArgoCDApplicationSetRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	si := meta.(*ServerInterface)
 	if err := si.initClients(ctx); err != nil {
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary:  "failed to init clients",
-				Detail:   err.Error(),
-			},
-		}
+		return errorToDiagnostics("failed to init clients", err)
 	}
 
 	name := d.Id()
@@ -114,13 +96,7 @@ func resourceArgoCDApplicationSetRead(ctx context.Context, d *schema.ResourceDat
 
 	err = flattenApplicationSet(appSet, d)
 	if err != nil {
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary:  fmt.Sprintf("application set %s could not be flattened", name),
-				Detail:   err.Error(),
-			},
-		}
+		return errorToDiagnostics(fmt.Sprintf("failed to flatten application set %s", name), err)
 	}
 
 	return nil
@@ -129,13 +105,7 @@ func resourceArgoCDApplicationSetRead(ctx context.Context, d *schema.ResourceDat
 func resourceArgoCDApplicationSetUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	si := meta.(*ServerInterface)
 	if err := si.initClients(ctx); err != nil {
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary:  "failed to init clients",
-				Detail:   err.Error(),
-			},
-		}
+		return errorToDiagnostics("failed to init clients", err)
 	}
 
 	if !si.isFeatureSupported(featureApplicationSet) {
@@ -148,13 +118,7 @@ func resourceArgoCDApplicationSetUpdate(ctx context.Context, d *schema.ResourceD
 
 	objectMeta, spec, err := expandApplicationSet(d, si.isFeatureSupported(featureMultipleApplicationSources))
 	if err != nil {
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary:  fmt.Sprintf("application set %s could not be updated", d.Id()),
-				Detail:   err.Error(),
-			},
-		}
+		return errorToDiagnostics(fmt.Sprintf("failed to expand application set %s", d.Id()), err)
 	}
 
 	if !si.isFeatureSupported(featureApplicationSetProgressiveSync) && spec.Strategy != nil {
@@ -183,13 +147,7 @@ func resourceArgoCDApplicationSetUpdate(ctx context.Context, d *schema.ResourceD
 func resourceArgoCDApplicationSetDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	si := meta.(*ServerInterface)
 	if err := si.initClients(ctx); err != nil {
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary:  "failed to init clients",
-				Detail:   err.Error(),
-			},
-		}
+		return errorToDiagnostics("failed to init clients", err)
 	}
 
 	_, err := si.ApplicationSetClient.Delete(ctx, &applicationset.ApplicationSetDeleteRequest{

--- a/argocd/resource_argocd_application_set.go
+++ b/argocd/resource_argocd_application_set.go
@@ -71,16 +71,8 @@ func resourceArgoCDApplicationSetCreate(ctx context.Context, d *schema.ResourceD
 		},
 	})
 	if err != nil {
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary:  fmt.Sprintf("application set %s could not be created", objectMeta.Name),
-				Detail:   err.Error(),
-			},
-		}
-	}
-
-	if as == nil {
+		return argoCDAPIError("create", "application set", objectMeta.Name, err)
+	} else if as == nil {
 		return []diag.Diagnostic{
 			{
 				Severity: diag.Error,
@@ -117,13 +109,7 @@ func resourceArgoCDApplicationSetRead(ctx context.Context, d *schema.ResourceDat
 			return diag.Diagnostics{}
 		}
 
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary:  "error getting application set",
-				Detail:   err.Error(),
-			},
-		}
+		return argoCDAPIError("read", "application set", name, err)
 	}
 
 	err = flattenApplicationSet(appSet, d)
@@ -188,13 +174,7 @@ func resourceArgoCDApplicationSetUpdate(ctx context.Context, d *schema.ResourceD
 	})
 
 	if err != nil {
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary:  "failed to update application set",
-				Detail:   err.Error(),
-			},
-		}
+		return argoCDAPIError("update", "application set", objectMeta.Name, err)
 	}
 
 	return resourceArgoCDApplicationSetRead(ctx, d, meta)
@@ -217,13 +197,7 @@ func resourceArgoCDApplicationSetDelete(ctx context.Context, d *schema.ResourceD
 	})
 
 	if err != nil && !strings.Contains(err.Error(), "NotFound") {
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary:  fmt.Sprintf("something went wrong during application set deletion: %s", err),
-				Detail:   err.Error(),
-			},
-		}
+		return argoCDAPIError("delete", "application set", d.Id(), err)
 	}
 
 	d.SetId("")

--- a/argocd/resource_argocd_application_set.go
+++ b/argocd/resource_argocd_application_set.go
@@ -41,16 +41,7 @@ func resourceArgoCDApplicationSetCreate(ctx context.Context, d *schema.ResourceD
 		}
 	}
 
-	featureApplicationSetSupported, err := si.isFeatureSupported(featureApplicationSet)
-	if err != nil {
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary:  "feature not supported",
-				Detail:   err.Error(),
-			},
-		}
-	} else if !featureApplicationSetSupported {
+	if !si.isFeatureSupported(featureApplicationSet) {
 		return []diag.Diagnostic{
 			{
 				Severity: diag.Error,
@@ -61,18 +52,7 @@ func resourceArgoCDApplicationSetCreate(ctx context.Context, d *schema.ResourceD
 		}
 	}
 
-	featureMultipleApplicationSourcesSupported, err := si.isFeatureSupported(featureMultipleApplicationSources)
-	if err != nil {
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary:  "feature not supported",
-				Detail:   err.Error(),
-			},
-		}
-	}
-
-	objectMeta, spec, err := expandApplicationSet(d, featureMultipleApplicationSourcesSupported)
+	objectMeta, spec, err := expandApplicationSet(d, si.isFeatureSupported(featureMultipleApplicationSources))
 	if err != nil {
 		return []diag.Diagnostic{
 			{
@@ -83,17 +63,7 @@ func resourceArgoCDApplicationSetCreate(ctx context.Context, d *schema.ResourceD
 		}
 	}
 
-	featureApplicationSetProgressiveSyncSupported, err := si.isFeatureSupported(featureApplicationSetProgressiveSync)
-	if err != nil {
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary:  "feature not supported",
-				Detail:   err.Error(),
-			},
-		}
-	} else if !featureApplicationSetProgressiveSyncSupported &&
-		spec.Strategy != nil {
+	if !si.isFeatureSupported(featureApplicationSetProgressiveSync) && spec.Strategy != nil {
 		return []diag.Diagnostic{
 			{
 				Severity: diag.Error,
@@ -197,16 +167,7 @@ func resourceArgoCDApplicationSetUpdate(ctx context.Context, d *schema.ResourceD
 		}
 	}
 
-	featureApplicationSetSupported, err := si.isFeatureSupported(featureApplicationSet)
-	if err != nil {
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary:  "feature not supported",
-				Detail:   err.Error(),
-			},
-		}
-	} else if !featureApplicationSetSupported {
+	if !si.isFeatureSupported(featureApplicationSet) {
 		return []diag.Diagnostic{
 			{
 				Severity: diag.Error,
@@ -221,18 +182,7 @@ func resourceArgoCDApplicationSetUpdate(ctx context.Context, d *schema.ResourceD
 		return nil
 	}
 
-	featureMultipleApplicationSourcesSupported, err := si.isFeatureSupported(featureMultipleApplicationSources)
-	if err != nil {
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary:  "feature not supported",
-				Detail:   err.Error(),
-			},
-		}
-	}
-
-	objectMeta, spec, err := expandApplicationSet(d, featureMultipleApplicationSourcesSupported)
+	objectMeta, spec, err := expandApplicationSet(d, si.isFeatureSupported(featureMultipleApplicationSources))
 	if err != nil {
 		return []diag.Diagnostic{
 			{
@@ -243,17 +193,7 @@ func resourceArgoCDApplicationSetUpdate(ctx context.Context, d *schema.ResourceD
 		}
 	}
 
-	featureApplicationSetProgressiveSyncSupported, err := si.isFeatureSupported(featureApplicationSetProgressiveSync)
-	if err != nil {
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary:  "feature not supported",
-				Detail:   err.Error(),
-			},
-		}
-	} else if !featureApplicationSetProgressiveSyncSupported &&
-		spec.Strategy != nil {
+	if !si.isFeatureSupported(featureApplicationSetProgressiveSync) && spec.Strategy != nil {
 		return []diag.Diagnostic{
 			{
 				Severity: diag.Error,

--- a/argocd/resource_argocd_application_set.go
+++ b/argocd/resource_argocd_application_set.go
@@ -9,6 +9,7 @@ import (
 	application "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/oboukili/terraform-provider-argocd/internal/features"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -35,17 +36,17 @@ func resourceArgoCDApplicationSetCreate(ctx context.Context, d *schema.ResourceD
 		return errorToDiagnostics("failed to init clients", err)
 	}
 
-	if !si.isFeatureSupported(featureApplicationSet) {
-		return featureNotSupported(featureApplicationSet)
+	if !si.isFeatureSupported(features.ApplicationSet) {
+		return featureNotSupported(features.ApplicationSet)
 	}
 
-	objectMeta, spec, err := expandApplicationSet(d, si.isFeatureSupported(featureMultipleApplicationSources))
+	objectMeta, spec, err := expandApplicationSet(d, si.isFeatureSupported(features.MultipleApplicationSources))
 	if err != nil {
 		return errorToDiagnostics("failed to expand application set", err)
 	}
 
-	if !si.isFeatureSupported(featureApplicationSetProgressiveSync) && spec.Strategy != nil {
-		return featureNotSupported(featureApplicationSetProgressiveSync)
+	if !si.isFeatureSupported(features.ApplicationSetProgressiveSync) && spec.Strategy != nil {
+		return featureNotSupported(features.ApplicationSetProgressiveSync)
 	}
 
 	as, err := si.ApplicationSetClient.Create(ctx, &applicationset.ApplicationSetCreateRequest{
@@ -108,21 +109,21 @@ func resourceArgoCDApplicationSetUpdate(ctx context.Context, d *schema.ResourceD
 		return errorToDiagnostics("failed to init clients", err)
 	}
 
-	if !si.isFeatureSupported(featureApplicationSet) {
-		return featureNotSupported(featureApplicationSet)
+	if !si.isFeatureSupported(features.ApplicationSet) {
+		return featureNotSupported(features.ApplicationSet)
 	}
 
 	if !d.HasChanges("metadata", "spec") {
 		return nil
 	}
 
-	objectMeta, spec, err := expandApplicationSet(d, si.isFeatureSupported(featureMultipleApplicationSources))
+	objectMeta, spec, err := expandApplicationSet(d, si.isFeatureSupported(features.MultipleApplicationSources))
 	if err != nil {
 		return errorToDiagnostics(fmt.Sprintf("failed to expand application set %s", d.Id()), err)
 	}
 
-	if !si.isFeatureSupported(featureApplicationSetProgressiveSync) && spec.Strategy != nil {
-		return featureNotSupported(featureApplicationSetProgressiveSync)
+	if !si.isFeatureSupported(features.ApplicationSetProgressiveSync) && spec.Strategy != nil {
+		return featureNotSupported(features.ApplicationSetProgressiveSync)
 	}
 
 	_, err = si.ApplicationSetClient.Create(ctx, &applicationset.ApplicationSetCreateRequest{

--- a/argocd/resource_argocd_application_set_test.go
+++ b/argocd/resource_argocd_application_set_test.go
@@ -5,11 +5,12 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/oboukili/terraform-provider-argocd/internal/features"
 )
 
 func TestAccArgoCDApplicationSet_clusters(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckFeatureSupported(t, featureApplicationSet) },
+		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckFeatureSupported(t, features.ApplicationSet) },
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
 			{
@@ -31,7 +32,7 @@ func TestAccArgoCDApplicationSet_clusters(t *testing.T) {
 
 func TestAccArgoCDApplicationSet_clustersSelector(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckFeatureSupported(t, featureApplicationSet) },
+		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckFeatureSupported(t, features.ApplicationSet) },
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
 			{
@@ -59,7 +60,7 @@ func TestAccArgoCDApplicationSet_clustersSelector(t *testing.T) {
 
 func TestAccArgoCDApplicationSet_clusterDecisionResource(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckFeatureSupported(t, featureApplicationSet) },
+		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckFeatureSupported(t, features.ApplicationSet) },
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
 			{
@@ -95,7 +96,7 @@ func TestAccArgoCDApplicationSet_clusterDecisionResource(t *testing.T) {
 
 func TestAccArgoCDApplicationSet_gitDirectories(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckFeatureSupported(t, featureApplicationSet) },
+		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckFeatureSupported(t, features.ApplicationSet) },
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
 			{
@@ -131,7 +132,7 @@ func TestAccArgoCDApplicationSet_gitDirectories(t *testing.T) {
 
 func TestAccArgoCDApplicationSet_gitFiles(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckFeatureSupported(t, featureApplicationSet) },
+		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckFeatureSupported(t, features.ApplicationSet) },
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
 			{
@@ -159,7 +160,7 @@ func TestAccArgoCDApplicationSet_gitFiles(t *testing.T) {
 
 func TestAccArgoCDApplicationSet_list(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckFeatureSupported(t, featureApplicationSet) },
+		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckFeatureSupported(t, features.ApplicationSet) },
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
 			{
@@ -191,7 +192,7 @@ func TestAccArgoCDApplicationSet_list(t *testing.T) {
 
 func TestAccArgoCDApplicationSet_matrix(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckFeatureSupported(t, featureApplicationSet) },
+		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckFeatureSupported(t, features.ApplicationSet) },
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
 			{
@@ -223,7 +224,7 @@ func TestAccArgoCDApplicationSet_matrix(t *testing.T) {
 
 func TestAccArgoCDApplicationSet_matrixNested(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckFeatureSupported(t, featureApplicationSet) },
+		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckFeatureSupported(t, features.ApplicationSet) },
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
 			{
@@ -259,7 +260,7 @@ func TestAccArgoCDApplicationSet_matrixNested(t *testing.T) {
 
 func TestAccArgoCDApplicationSet_matrixInvalid(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckFeatureSupported(t, featureApplicationSet) },
+		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckFeatureSupported(t, features.ApplicationSet) },
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
 			{
@@ -284,7 +285,7 @@ func TestAccArgoCDApplicationSet_matrixInvalid(t *testing.T) {
 
 func TestAccArgoCDApplicationSet_merge(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckFeatureSupported(t, featureApplicationSet) },
+		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckFeatureSupported(t, features.ApplicationSet) },
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
 			{
@@ -325,7 +326,7 @@ func TestAccArgoCDApplicationSet_merge(t *testing.T) {
 
 func TestAccArgoCDApplicationSet_mergeNested(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckFeatureSupported(t, featureApplicationSet) },
+		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckFeatureSupported(t, features.ApplicationSet) },
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
 			{
@@ -371,7 +372,7 @@ func TestAccArgoCDApplicationSet_mergeNested(t *testing.T) {
 
 func TestAccArgoCDApplicationSet_scmProviderAzureDevOps(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckFeatureSupported(t, featureApplicationSet) },
+		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckFeatureSupported(t, features.ApplicationSet) },
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
 			{
@@ -400,7 +401,7 @@ func TestAccArgoCDApplicationSet_scmProviderAzureDevOps(t *testing.T) {
 
 func TestAccArgoCDApplicationSet_scmProviderBitbucketCloud(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckFeatureSupported(t, featureApplicationSet) },
+		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckFeatureSupported(t, features.ApplicationSet) },
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
 			{
@@ -429,7 +430,7 @@ func TestAccArgoCDApplicationSet_scmProviderBitbucketCloud(t *testing.T) {
 
 func TestAccArgoCDApplicationSet_scmProviderBitbucketServer(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckFeatureSupported(t, featureApplicationSet) },
+		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckFeatureSupported(t, features.ApplicationSet) },
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
 			{
@@ -458,7 +459,7 @@ func TestAccArgoCDApplicationSet_scmProviderBitbucketServer(t *testing.T) {
 
 func TestAccArgoCDApplicationSet_scmProviderGitea(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckFeatureSupported(t, featureApplicationSet) },
+		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckFeatureSupported(t, features.ApplicationSet) },
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
 			{
@@ -487,7 +488,7 @@ func TestAccArgoCDApplicationSet_scmProviderGitea(t *testing.T) {
 
 func TestAccArgoCDApplicationSet_scmProviderGithub(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckFeatureSupported(t, featureApplicationSet) },
+		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckFeatureSupported(t, features.ApplicationSet) },
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
 			{
@@ -516,7 +517,7 @@ func TestAccArgoCDApplicationSet_scmProviderGithub(t *testing.T) {
 
 func TestAccArgoCDApplicationSet_scmProviderGitlab(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckFeatureSupported(t, featureApplicationSet) },
+		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckFeatureSupported(t, features.ApplicationSet) },
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
 			{
@@ -545,7 +546,7 @@ func TestAccArgoCDApplicationSet_scmProviderGitlab(t *testing.T) {
 
 func TestAccArgoCDApplicationSet_scmProviderWithFilters(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckFeatureSupported(t, featureApplicationSet) },
+		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckFeatureSupported(t, features.ApplicationSet) },
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
 			{
@@ -589,7 +590,7 @@ func TestAccArgoCDApplicationSet_scmProviderWithFilters(t *testing.T) {
 
 func TestAccArgoCDApplicationSet_pullRequestBitbucketServer(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckFeatureSupported(t, featureApplicationSet) },
+		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckFeatureSupported(t, features.ApplicationSet) },
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
 			{
@@ -618,7 +619,7 @@ func TestAccArgoCDApplicationSet_pullRequestBitbucketServer(t *testing.T) {
 
 func TestAccArgoCDApplicationSet_pullRequestGitea(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckFeatureSupported(t, featureApplicationSet) },
+		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckFeatureSupported(t, features.ApplicationSet) },
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
 			{
@@ -647,7 +648,7 @@ func TestAccArgoCDApplicationSet_pullRequestGitea(t *testing.T) {
 
 func TestAccArgoCDApplicationSet_pullRequestGithub(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckFeatureSupported(t, featureApplicationSet) },
+		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckFeatureSupported(t, features.ApplicationSet) },
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
 			{
@@ -681,7 +682,7 @@ func TestAccArgoCDApplicationSet_pullRequestGithub(t *testing.T) {
 
 func TestAccArgoCDApplicationSet_pullRequestGitlab(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckFeatureSupported(t, featureApplicationSet) },
+		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckFeatureSupported(t, features.ApplicationSet) },
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
 			{
@@ -715,7 +716,7 @@ func TestAccArgoCDApplicationSet_pullRequestGitlab(t *testing.T) {
 
 func TestAccArgoCDApplicationSet_mergeInvalid(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckFeatureSupported(t, featureApplicationSet) },
+		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckFeatureSupported(t, features.ApplicationSet) },
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
 			{
@@ -736,7 +737,7 @@ func TestAccArgoCDApplicationSet_mergeInvalid(t *testing.T) {
 
 func TestAccArgoCDApplicationSet_generatorTemplate(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckFeatureSupported(t, featureApplicationSet) },
+		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckFeatureSupported(t, features.ApplicationSet) },
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
 			{
@@ -770,7 +771,7 @@ func TestAccArgoCDApplicationSet_generatorTemplate(t *testing.T) {
 
 func TestAccArgoCDApplicationSet_goTemplate(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckFeatureSupported(t, featureApplicationSet) },
+		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckFeatureSupported(t, features.ApplicationSet) },
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
 			{
@@ -799,7 +800,7 @@ func TestAccArgoCDApplicationSet_goTemplate(t *testing.T) {
 
 func TestAccArgoCDApplicationSet_syncPolicy(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckFeatureSupported(t, featureApplicationSet) },
+		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckFeatureSupported(t, features.ApplicationSet) },
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
 			{
@@ -828,7 +829,7 @@ func TestAccArgoCDApplicationSet_syncPolicy(t *testing.T) {
 
 func TestAccArgoCDApplicationSet_progressiveSync(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckFeatureSupported(t, featureApplicationSetProgressiveSync) },
+		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckFeatureSupported(t, features.ApplicationSetProgressiveSync) },
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
 			{

--- a/argocd/resource_argocd_application_test.go
+++ b/argocd/resource_argocd_application_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/oboukili/terraform-provider-argocd/internal/features"
 )
 
 func TestAccArgoCDApplication(t *testing.T) {
@@ -896,7 +897,7 @@ func TestAccArgoCDApplication_CustomNamespace(t *testing.T) {
 	name := acctest.RandomWithPrefix("test-acc")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckFeatureSupported(t, featureProjectSourceNamespaces) },
+		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckFeatureSupported(t, features.ProjectSourceNamespaces) },
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
 			{
@@ -920,7 +921,7 @@ func TestAccArgoCDApplication_CustomNamespace(t *testing.T) {
 
 func TestAccArgoCDApplication_MultipleSources(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckFeatureSupported(t, featureMultipleApplicationSources) },
+		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckFeatureSupported(t, features.MultipleApplicationSources) },
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
 			{
@@ -954,7 +955,7 @@ func TestAccArgoCDApplication_MultipleSources(t *testing.T) {
 
 func TestAccArgoCDApplication_HelmValuesFromExternalGitRepo(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckFeatureSupported(t, featureMultipleApplicationSources) },
+		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckFeatureSupported(t, features.MultipleApplicationSources) },
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
 			{

--- a/argocd/resource_argocd_cluster.go
+++ b/argocd/resource_argocd_cluster.go
@@ -47,47 +47,6 @@ func resourceArgoCDClusterCreate(ctx context.Context, d *schema.ResourceData, me
 		}
 	}
 
-	featureProjectScopedClustersSupported, err := si.isFeatureSupported(featureProjectScopedClusters)
-	if err != nil {
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary:  "feature not supported",
-				Detail:   err.Error(),
-			},
-		}
-	} else if !featureProjectScopedClustersSupported && cluster.Project != "" {
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary: fmt.Sprintf(
-					"cluster project is only supported from ArgoCD %s onwards",
-					featureVersionConstraintsMap[featureProjectScopedClusters].String()),
-				Detail: "See https://argo-cd.readthedocs.io/en/stable/user-guide/projects/#project-scoped-repositories-and-clusters",
-			},
-		}
-	}
-
-	featureClusterMetadataSupported, err := si.isFeatureSupported(featureClusterMetadata)
-	if err != nil {
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary:  "feature not supported",
-				Detail:   err.Error(),
-			},
-		}
-	} else if !featureClusterMetadataSupported && (len(cluster.Annotations) != 0 || len(cluster.Labels) != 0) {
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary: fmt.Sprintf(
-					"cluster metadata is only supported from ArgoCD %s onwards",
-					featureVersionConstraintsMap[featureClusterMetadata].String()),
-			},
-		}
-	}
-
 	// Need a full lock here to avoid race conditions between List existing clusters and creating a new one
 	tokenMutexClusters.Lock()
 
@@ -215,47 +174,6 @@ func resourceArgoCDClusterUpdate(ctx context.Context, d *schema.ResourceData, me
 				Severity: diag.Error,
 				Summary:  fmt.Sprintf("could not expand cluster attributes: %s", err),
 				Detail:   err.Error(),
-			},
-		}
-	}
-
-	featureProjectScopedClustersSupported, err := si.isFeatureSupported(featureProjectScopedClusters)
-	if err != nil {
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary:  "feature not supported",
-				Detail:   err.Error(),
-			},
-		}
-	} else if !featureProjectScopedClustersSupported && cluster.Project != "" {
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary: fmt.Sprintf(
-					"cluster project is only supported from ArgoCD %s onwards",
-					featureVersionConstraintsMap[featureProjectScopedClusters].String()),
-				Detail: "See https://argo-cd.readthedocs.io/en/stable/user-guide/projects/#project-scoped-repositories-and-clusters",
-			},
-		}
-	}
-
-	featureClusterMetadataSupported, err := si.isFeatureSupported(featureClusterMetadata)
-	if err != nil {
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary:  "feature not supported",
-				Detail:   err.Error(),
-			},
-		}
-	} else if !featureClusterMetadataSupported && (len(cluster.Annotations) != 0 || len(cluster.Labels) != 0) {
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary: fmt.Sprintf(
-					"cluster metadata is only supported from ArgoCD %s onwards",
-					featureVersionConstraintsMap[featureClusterMetadata].String()),
 			},
 		}
 	}

--- a/argocd/resource_argocd_cluster.go
+++ b/argocd/resource_argocd_cluster.go
@@ -60,14 +60,7 @@ func resourceArgoCDClusterCreate(ctx context.Context, d *schema.ResourceData, me
 
 	if err != nil {
 		tokenMutexClusters.Unlock()
-
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary:  fmt.Sprintf("could not get current clusters list:  %s", err),
-				Detail:   err.Error(),
-			},
-		}
+		return argoCDAPIError("list", "existing clusters", cluster.Server, err)
 	}
 
 	rtrimmedServer := strings.TrimRight(cluster.Server, "/")
@@ -92,13 +85,7 @@ func resourceArgoCDClusterCreate(ctx context.Context, d *schema.ResourceData, me
 	tokenMutexClusters.Unlock()
 
 	if err != nil {
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary:  fmt.Sprintf("something went wrong during cluster resource creation: %s", err),
-				Detail:   err.Error(),
-			},
-		}
+		return argoCDAPIError("create", "cluster", cluster.Server, err)
 	}
 
 	// Check if the name has been defaulted to server (when omitted)
@@ -133,13 +120,7 @@ func resourceArgoCDClusterRead(ctx context.Context, d *schema.ResourceData, meta
 			return nil
 		}
 
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary:  fmt.Sprintf("could not get cluster information: %s", err),
-				Detail:   err.Error(),
-			},
-		}
+		return argoCDAPIError("read", "cluster", d.Id(), err)
 	}
 
 	if err = flattenCluster(c, d); err != nil {
@@ -183,13 +164,7 @@ func resourceArgoCDClusterUpdate(ctx context.Context, d *schema.ResourceData, me
 	tokenMutexClusters.Unlock()
 
 	if err != nil {
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary:  fmt.Sprintf("something went wrong during cluster update: %s", err),
-				Detail:   err.Error(),
-			},
-		}
+		return argoCDAPIError("update", "cluster", cluster.Server, err)
 	}
 
 	return resourceArgoCDClusterRead(ctx, d, meta)
@@ -217,13 +192,7 @@ func resourceArgoCDClusterDelete(ctx context.Context, d *schema.ResourceData, me
 			return nil
 		}
 
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary:  fmt.Sprintf("something went wrong during cluster deletion: %s", err),
-				Detail:   err.Error(),
-			},
-		}
+		return argoCDAPIError("delete", "cluster", d.Id(), err)
 	}
 
 	d.SetId("")

--- a/argocd/resource_argocd_cluster.go
+++ b/argocd/resource_argocd_cluster.go
@@ -27,24 +27,12 @@ func resourceArgoCDCluster() *schema.Resource {
 func resourceArgoCDClusterCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	si := meta.(*ServerInterface)
 	if err := si.initClients(ctx); err != nil {
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary:  "failed to init clients",
-				Detail:   err.Error(),
-			},
-		}
+		return errorToDiagnostics("failed to init clients", err)
 	}
 
 	cluster, err := expandCluster(d)
 	if err != nil {
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary:  fmt.Sprintf("could not expand cluster attributes: %s", err),
-				Detail:   err.Error(),
-			},
-		}
+		return errorToDiagnostics("failed to expand cluster", err)
 	}
 
 	// Need a full lock here to avoid race conditions between List existing clusters and creating a new one
@@ -60,7 +48,7 @@ func resourceArgoCDClusterCreate(ctx context.Context, d *schema.ResourceData, me
 
 	if err != nil {
 		tokenMutexClusters.Unlock()
-		return argoCDAPIError("list", "existing clusters", cluster.Server, err)
+		return errorToDiagnostics(fmt.Sprintf("failed to list existing clusters when creating cluster %s", cluster.Server), err)
 	}
 
 	rtrimmedServer := strings.TrimRight(cluster.Server, "/")
@@ -101,13 +89,7 @@ func resourceArgoCDClusterCreate(ctx context.Context, d *schema.ResourceData, me
 func resourceArgoCDClusterRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	si := meta.(*ServerInterface)
 	if err := si.initClients(ctx); err != nil {
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary:  "failed to init clients",
-				Detail:   err.Error(),
-			},
-		}
+		return errorToDiagnostics("failed to init clients", err)
 	}
 
 	tokenMutexClusters.RLock()
@@ -124,13 +106,7 @@ func resourceArgoCDClusterRead(ctx context.Context, d *schema.ResourceData, meta
 	}
 
 	if err = flattenCluster(c, d); err != nil {
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary:  "could not flatten cluster",
-				Detail:   err.Error(),
-			},
-		}
+		return errorToDiagnostics(fmt.Sprintf("failed to flatten cluster %s", d.Id()), err)
 	}
 
 	return nil
@@ -139,24 +115,12 @@ func resourceArgoCDClusterRead(ctx context.Context, d *schema.ResourceData, meta
 func resourceArgoCDClusterUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	si := meta.(*ServerInterface)
 	if err := si.initClients(ctx); err != nil {
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary:  "failed to init clients",
-				Detail:   err.Error(),
-			},
-		}
+		return errorToDiagnostics("failed to init clients", err)
 	}
 
 	cluster, err := expandCluster(d)
 	if err != nil {
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary:  fmt.Sprintf("could not expand cluster attributes: %s", err),
-				Detail:   err.Error(),
-			},
-		}
+		return errorToDiagnostics(fmt.Sprintf("failed to expand cluster %s", d.Id()), err)
 	}
 
 	tokenMutexClusters.Lock()
@@ -173,13 +137,7 @@ func resourceArgoCDClusterUpdate(ctx context.Context, d *schema.ResourceData, me
 func resourceArgoCDClusterDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	si := meta.(*ServerInterface)
 	if err := si.initClients(ctx); err != nil {
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary:  "failed to init clients",
-				Detail:   err.Error(),
-			},
-		}
+		return errorToDiagnostics("failed to init clients", err)
 	}
 
 	tokenMutexClusters.Lock()

--- a/argocd/resource_argocd_cluster_test.go
+++ b/argocd/resource_argocd_cluster_test.go
@@ -81,7 +81,7 @@ func TestAccArgoCDCluster(t *testing.T) {
 
 func TestAccArgoCDCluster_projectScope(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckFeatureSupported(t, featureProjectScopedClusters) },
+		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
 			{
@@ -119,7 +119,7 @@ func TestAccArgoCDCluster_optionalName(t *testing.T) {
 	name := acctest.RandString(10)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckFeatureSupported(t, featureProjectScopedClusters) },
+		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
 			{
@@ -190,7 +190,7 @@ func TestAccArgoCDCluster_metadata(t *testing.T) {
 	clusterName := acctest.RandString(10)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckFeatureSupported(t, featureClusterMetadata) },
+		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
 			{
@@ -275,7 +275,7 @@ func TestAccArgoCDCluster_metadata(t *testing.T) {
 
 func TestAccArgoCDCluster_invalidSameServer(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckFeatureSupported(t, featureProjectScopedClusters) },
+		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
 			{
@@ -298,7 +298,7 @@ func TestAccArgoCDCluster_namespacesErrorWhenEmpty(t *testing.T) {
 	name := acctest.RandString(10)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckFeatureSupported(t, featureProjectScopedClusters) },
+		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
 			{

--- a/argocd/resource_argocd_project.go
+++ b/argocd/resource_argocd_project.go
@@ -11,6 +11,7 @@ import (
 	application "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/oboukili/terraform-provider-argocd/internal/features"
 )
 
 func resourceArgoCDProject() *schema.Resource {
@@ -56,10 +57,10 @@ func resourceArgoCDProjectCreate(ctx context.Context, d *schema.ResourceData, me
 
 	projectName := objectMeta.Name
 
-	if !si.isFeatureSupported(featureProjectSourceNamespaces) {
+	if !si.isFeatureSupported(features.ProjectSourceNamespaces) {
 		_, sourceNamespacesOk := d.GetOk("spec.0.source_namespaces")
 		if sourceNamespacesOk {
-			return featureNotSupported(featureProjectSourceNamespaces)
+			return featureNotSupported(features.ProjectSourceNamespaces)
 		}
 	}
 
@@ -162,10 +163,10 @@ func resourceArgoCDProjectUpdate(ctx context.Context, d *schema.ResourceData, me
 		return errorToDiagnostics(fmt.Sprintf("failed to expand project %s", d.Id()), err)
 	}
 
-	if !si.isFeatureSupported(featureProjectSourceNamespaces) {
+	if !si.isFeatureSupported(features.ProjectSourceNamespaces) {
 		_, sourceNamespacesOk := d.GetOk("spec.0.source_namespaces")
 		if sourceNamespacesOk {
-			return featureNotSupported(featureProjectSourceNamespaces)
+			return featureNotSupported(features.ProjectSourceNamespaces)
 		}
 	}
 

--- a/argocd/resource_argocd_project.go
+++ b/argocd/resource_argocd_project.go
@@ -71,14 +71,7 @@ func resourceArgoCDProjectCreate(ctx context.Context, d *schema.ResourceData, me
 	if !si.isFeatureSupported(featureProjectSourceNamespaces) {
 		_, sourceNamespacesOk := d.GetOk("spec.0.source_namespaces")
 		if sourceNamespacesOk {
-			return []diag.Diagnostic{
-				{
-					Severity: diag.Error,
-					Summary: fmt.Sprintf(
-						"project source_namespaces is only supported from ArgoCD %s onwards",
-						featureVersionConstraintsMap[featureProjectSourceNamespaces].String()),
-				},
-			}
+			return featureNotSupported(featureProjectSourceNamespaces)
 		}
 	}
 
@@ -227,14 +220,7 @@ func resourceArgoCDProjectUpdate(ctx context.Context, d *schema.ResourceData, me
 	if !si.isFeatureSupported(featureProjectSourceNamespaces) {
 		_, sourceNamespacesOk := d.GetOk("spec.0.source_namespaces")
 		if sourceNamespacesOk {
-			return []diag.Diagnostic{
-				{
-					Severity: diag.Error,
-					Summary: fmt.Sprintf(
-						"project source_namespaces is only supported from ArgoCD %s onwards",
-						featureVersionConstraintsMap[featureProjectSourceNamespaces].String()),
-				},
-			}
+			return featureNotSupported(featureProjectSourceNamespaces)
 		}
 	}
 

--- a/argocd/resource_argocd_project.go
+++ b/argocd/resource_argocd_project.go
@@ -68,16 +68,7 @@ func resourceArgoCDProjectCreate(ctx context.Context, d *schema.ResourceData, me
 
 	projectName := objectMeta.Name
 
-	featureProjectSourceNamespacesSupported, err := si.isFeatureSupported(featureProjectSourceNamespaces)
-	if err != nil {
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary:  "feature not supported",
-				Detail:   err.Error(),
-			},
-		}
-	} else if !featureProjectSourceNamespacesSupported {
+	if !si.isFeatureSupported(featureProjectSourceNamespaces) {
 		_, sourceNamespacesOk := d.GetOk("spec.0.source_namespaces")
 		if sourceNamespacesOk {
 			return []diag.Diagnostic{
@@ -233,18 +224,7 @@ func resourceArgoCDProjectUpdate(ctx context.Context, d *schema.ResourceData, me
 		}
 	}
 
-	projectName := objectMeta.Name
-
-	featureProjectSourceNamespacesSupported, err := si.isFeatureSupported(featureProjectSourceNamespaces)
-	if err != nil {
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary:  "feature not supported",
-				Detail:   err.Error(),
-			},
-		}
-	} else if !featureProjectSourceNamespacesSupported {
+	if !si.isFeatureSupported(featureProjectSourceNamespaces) {
 		_, sourceNamespacesOk := d.GetOk("spec.0.source_namespaces")
 		if sourceNamespacesOk {
 			return []diag.Diagnostic{
@@ -257,6 +237,8 @@ func resourceArgoCDProjectUpdate(ctx context.Context, d *schema.ResourceData, me
 			}
 		}
 	}
+
+	projectName := objectMeta.Name
 
 	if _, ok := tokenMutexProjectMap[projectName]; !ok {
 		tokenMutexProjectMap[projectName] = &sync.RWMutex{}

--- a/argocd/resource_argocd_project_test.go
+++ b/argocd/resource_argocd_project_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/oboukili/terraform-provider-argocd/internal/features"
 )
 
 func TestAccArgoCDProject(t *testing.T) {
@@ -201,7 +202,7 @@ func TestAccArgoCDProjectWithLogsExecRolePolicy(t *testing.T) {
 	name := acctest.RandomWithPrefix("test-acc")
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckFeatureSupported(t, featureExecLogsPolicy) },
+		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckFeatureSupported(t, features.ExecLogsPolicy) },
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
 			{
@@ -226,7 +227,7 @@ func TestAccArgoCDProjectWithSourceNamespaces(t *testing.T) {
 	name := acctest.RandomWithPrefix("test-acc")
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckFeatureSupported(t, featureProjectSourceNamespaces) },
+		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckFeatureSupported(t, features.ProjectSourceNamespaces) },
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
 			{

--- a/argocd/resource_argocd_project_test.go
+++ b/argocd/resource_argocd_project_test.go
@@ -176,7 +176,7 @@ func TestAccArgoCDProjectWithClustersRepositoriesRolePolicy(t *testing.T) {
 	name := acctest.RandomWithPrefix("test-acc")
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckFeatureSupported(t, featureProjectScopedClusters) },
+		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
 			{

--- a/argocd/resource_argocd_project_token.go
+++ b/argocd/resource_argocd_project_token.go
@@ -230,13 +230,7 @@ func resourceArgoCDProjectTokenCreate(ctx context.Context, d *schema.ResourceDat
 	tokenMutexProjectMap[projectName].Unlock()
 
 	if err != nil {
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary:  fmt.Sprintf("token for project %s could not be created", projectName),
-				Detail:   err.Error(),
-			},
-		}
+		return argoCDAPIError("create", "token for project", projectName, err)
 	}
 
 	token, err := jwt.ParseString(resp.GetToken())
@@ -354,15 +348,9 @@ func resourceArgoCDProjectTokenRead(ctx context.Context, d *schema.ResourceData,
 		if strings.Contains(err.Error(), "NotFound") {
 			d.SetId("")
 			return nil
-		} else {
-			return []diag.Diagnostic{
-				{
-					Severity: diag.Error,
-					Summary:  fmt.Sprintf("token for project %s could not be read", projectName),
-					Detail:   err.Error(),
-				},
-			}
 		}
+
+		return argoCDAPIError("read", "project", projectName, err)
 	}
 
 	tokenMutexProjectMap[projectName].RLock()
@@ -481,13 +469,7 @@ func resourceArgoCDProjectTokenDelete(ctx context.Context, d *schema.ResourceDat
 	tokenMutexProjectMap[projectName].Unlock()
 
 	if err != nil {
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary:  fmt.Sprintf("token for project %s could not be deleted", projectName),
-				Detail:   err.Error(),
-			},
-		}
+		return argoCDAPIError("delete", "token for project", projectName, err)
 	}
 
 	d.SetId("")

--- a/argocd/resource_argocd_repository.go
+++ b/argocd/resource_argocd_repository.go
@@ -30,24 +30,12 @@ func resourceArgoCDRepository() *schema.Resource {
 func resourceArgoCDRepositoryCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	si := meta.(*ServerInterface)
 	if err := si.initClients(ctx); err != nil {
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary:  "failed to init clients",
-				Detail:   err.Error(),
-			},
-		}
+		return errorToDiagnostics("failed to init clients", err)
 	}
 
 	repo, err := expandRepository(d)
 	if err != nil {
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary:  fmt.Sprintf("could not expand repository attributes: %s", err),
-				Detail:   err.Error(),
-			},
-		}
+		return errorToDiagnostics("failed to expand repository", err)
 	}
 
 	if err := resource.RetryContext(ctx, d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
@@ -90,13 +78,7 @@ func resourceArgoCDRepositoryCreate(ctx context.Context, d *schema.ResourceData,
 func resourceArgoCDRepositoryRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	si := meta.(*ServerInterface)
 	if err := si.initClients(ctx); err != nil {
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary:  "failed to init clients",
-				Detail:   err.Error(),
-			},
-		}
+		return errorToDiagnostics("failed to init clients", err)
 	}
 
 	tokenMutexConfiguration.RLock()
@@ -117,13 +99,7 @@ func resourceArgoCDRepositoryRead(ctx context.Context, d *schema.ResourceData, m
 	}
 
 	if err = flattenRepository(r, d); err != nil {
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary:  fmt.Sprintf("repository %s could not be flattened", d.Id()),
-				Detail:   err.Error(),
-			},
-		}
+		return errorToDiagnostics(fmt.Sprintf("failed to flatten repository %s", d.Id()), err)
 	}
 
 	return nil
@@ -132,24 +108,12 @@ func resourceArgoCDRepositoryRead(ctx context.Context, d *schema.ResourceData, m
 func resourceArgoCDRepositoryUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	si := meta.(*ServerInterface)
 	if err := si.initClients(ctx); err != nil {
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary:  "failed to init clients",
-				Detail:   err.Error(),
-			},
-		}
+		return errorToDiagnostics("failed to init clients", err)
 	}
 
 	repo, err := expandRepository(d)
 	if err != nil {
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary:  fmt.Sprintf("could not expand repository attributes: %s", err),
-				Detail:   err.Error(),
-			},
-		}
+		return errorToDiagnostics(fmt.Sprintf("failed to expand repository %s", d.Id()), err)
 	}
 
 	tokenMutexConfiguration.Lock()
@@ -164,13 +128,7 @@ func resourceArgoCDRepositoryUpdate(ctx context.Context, d *schema.ResourceData,
 	}
 
 	if r == nil {
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary:  fmt.Sprintf("argoCD did not return an error or a repository result for ID %s", d.Id()),
-				Detail:   err.Error(),
-			},
-		}
+		return errorToDiagnostics(fmt.Sprintf("ArgoCD did not return an error or a repository result for ID %s", d.Id()), err)
 	}
 
 	if r.ConnectionState.Status == application.ConnectionStatusFailed {
@@ -190,13 +148,7 @@ func resourceArgoCDRepositoryUpdate(ctx context.Context, d *schema.ResourceData,
 func resourceArgoCDRepositoryDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	si := meta.(*ServerInterface)
 	if err := si.initClients(ctx); err != nil {
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary:  "failed to init clients",
-				Detail:   err.Error(),
-			},
-		}
+		return errorToDiagnostics("failed to init clients", err)
 	}
 
 	tokenMutexConfiguration.Lock()

--- a/argocd/resource_argocd_repository_certificate.go
+++ b/argocd/resource_argocd_repository_certificate.go
@@ -37,24 +37,6 @@ func resourceArgoCDRepositoryCertificatesCreate(ctx context.Context, d *schema.R
 		}
 	}
 
-	if featureRepositoryCertificateSupported, err := si.isFeatureSupported(featureRepositoryCertificates); err != nil {
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary:  "feature not supported",
-				Detail:   err.Error(),
-			},
-		}
-	} else if !featureRepositoryCertificateSupported {
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary: fmt.Sprintf(
-					"repository certificate is only supported from ArgoCD %s onwards",
-					featureVersionConstraintsMap[featureRepositoryCertificates].String()),
-			},
-		}
-	}
 
 	// Not doing a RLock here because we can have a race-condition between the ListCertificates & CreateCertificate
 	tokenMutexConfiguration.Lock()
@@ -195,27 +177,6 @@ func resourceArgoCDRepositoryCertificatesRead(ctx context.Context, d *schema.Res
 		}
 	}
 
-	featureRepositoryCertificateSupported, err := si.isFeatureSupported(featureRepositoryCertificates)
-	if err != nil {
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary:  "feature not supported",
-				Detail:   err.Error(),
-			},
-		}
-	}
-
-	if !featureRepositoryCertificateSupported {
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary: fmt.Sprintf(
-					"repository certificate is only supported from ArgoCD %s onwards",
-					featureVersionConstraintsMap[featureRepositoryCertificates].String()),
-			},
-		}
-	}
 
 	certType, certSubType, serverName, err := fromId(d.Id())
 	if err != nil {
@@ -304,27 +265,6 @@ func resourceArgoCDRepositoryCertificatesDelete(ctx context.Context, d *schema.R
 		}
 	}
 
-	featureRepositoryCertificateSupported, err := si.isFeatureSupported(featureRepositoryCertificates)
-	if err != nil {
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary:  "feature not supported",
-				Detail:   err.Error(),
-			},
-		}
-	}
-
-	if !featureRepositoryCertificateSupported {
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary: fmt.Sprintf(
-					"repository certificate is only supported from ArgoCD %s onwards",
-					featureVersionConstraintsMap[featureRepositoryCertificates].String()),
-			},
-		}
-	}
 
 	certType, certSubType, serverName, err := fromId(d.Id())
 	if err != nil {

--- a/argocd/resource_argocd_repository_credentials.go
+++ b/argocd/resource_argocd_repository_credentials.go
@@ -31,24 +31,12 @@ func resourceArgoCDRepositoryCredentials() *schema.Resource {
 func resourceArgoCDRepositoryCredentialsCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	si := meta.(*ServerInterface)
 	if err := si.initClients(ctx); err != nil {
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary:  "failed to init clients",
-				Detail:   err.Error(),
-			},
-		}
+		return errorToDiagnostics("failed to init clients", err)
 	}
 
 	repoCreds, err := expandRepositoryCredentials(d)
 	if err != nil {
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary:  fmt.Sprintf("could not expand repository credential attributes: %s", err),
-				Detail:   err.Error(),
-			},
-		}
+		return errorToDiagnostics("failed to expand repository credentials", err)
 	}
 
 	tokenMutexConfiguration.Lock()
@@ -73,13 +61,7 @@ func resourceArgoCDRepositoryCredentialsCreate(ctx context.Context, d *schema.Re
 func resourceArgoCDRepositoryCredentialsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	si := meta.(*ServerInterface)
 	if err := si.initClients(ctx); err != nil {
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary:  "failed to init clients",
-				Detail:   err.Error(),
-			},
-		}
+		return errorToDiagnostics("failed to init clients", err)
 	}
 
 	tokenMutexConfiguration.RLock()
@@ -117,24 +99,12 @@ func resourceArgoCDRepositoryCredentialsRead(ctx context.Context, d *schema.Reso
 func resourceArgoCDRepositoryCredentialsUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	si := meta.(*ServerInterface)
 	if err := si.initClients(ctx); err != nil {
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary:  "failed to init clients",
-				Detail:   err.Error(),
-			},
-		}
+		return errorToDiagnostics("failed to init clients", err)
 	}
 
 	repoCreds, err := expandRepositoryCredentials(d)
 	if err != nil {
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary:  fmt.Sprintf("could not expand repository credential attributes: %s", err),
-				Detail:   err.Error(),
-			},
-		}
+		return errorToDiagnostics(fmt.Sprintf("failed to expand repository credentials %s", d.Id()), err)
 	}
 
 	tokenMutexConfiguration.Lock()
@@ -157,13 +127,7 @@ func resourceArgoCDRepositoryCredentialsUpdate(ctx context.Context, d *schema.Re
 func resourceArgoCDRepositoryCredentialsDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	si := meta.(*ServerInterface)
 	if err := si.initClients(ctx); err != nil {
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary:  "failed to init clients",
-				Detail:   err.Error(),
-			},
-		}
+		return errorToDiagnostics("failed to init clients", err)
 	}
 
 	tokenMutexConfiguration.Lock()

--- a/argocd/resource_argocd_repository_credentials.go
+++ b/argocd/resource_argocd_repository_credentials.go
@@ -62,13 +62,7 @@ func resourceArgoCDRepositoryCredentialsCreate(ctx context.Context, d *schema.Re
 	tokenMutexConfiguration.Unlock()
 
 	if err != nil {
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary:  fmt.Sprintf("credentials for repository %s could not be created", repoCreds.URL),
-				Detail:   err.Error(),
-			},
-		}
+		return argoCDAPIError("create", "repository credentials", repoCreds.URL, err)
 	}
 
 	d.SetId(rc.URL)
@@ -95,14 +89,7 @@ func resourceArgoCDRepositoryCredentialsRead(ctx context.Context, d *schema.Reso
 	tokenMutexConfiguration.RUnlock()
 
 	if err != nil {
-		// TODO: check for NotFound condition?
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary:  fmt.Sprintf("credentials for repository %s could not be listed", d.Id()),
-				Detail:   err.Error(),
-			},
-		}
+		return argoCDAPIError("read", "repository credentials", d.Id(), err)
 	} else if rcl == nil || len(rcl.Items) == 0 {
 		// Repository credentials have already been deleted in an out-of-band fashion
 		d.SetId("")
@@ -159,13 +146,7 @@ func resourceArgoCDRepositoryCredentialsUpdate(ctx context.Context, d *schema.Re
 	tokenMutexConfiguration.Unlock()
 
 	if err != nil {
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary:  fmt.Sprintf("credentials for repository %s could not be updated", repoCreds.URL),
-				Detail:   err.Error(),
-			},
-		}
+		return argoCDAPIError("update", "repository credentials", repoCreds.URL, err)
 	}
 
 	d.SetId(r.URL)
@@ -199,13 +180,7 @@ func resourceArgoCDRepositoryCredentialsDelete(ctx context.Context, d *schema.Re
 			return nil
 		}
 
-		return []diag.Diagnostic{
-			{
-				Severity: diag.Error,
-				Summary:  fmt.Sprintf("credentials for repository %s could not be deleted", d.Id()),
-				Detail:   err.Error(),
-			},
-		}
+		return argoCDAPIError("delete", "repository credentials", d.Id(), err)
 	}
 
 	d.SetId("")

--- a/argocd/resource_argocd_repository_test.go
+++ b/argocd/resource_argocd_repository_test.go
@@ -2,7 +2,6 @@ package argocd
 
 import (
 	"fmt"
-	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -113,35 +112,6 @@ func TestAccArgoCDRepository_PrivateSSH(t *testing.T) {
 					"Successful",
 					10,
 				),
-			},
-		},
-	})
-}
-
-func TestAccArgoCDRepositoryScoped_NotSupported_On_OlderVersions(t *testing.T) {
-	name := acctest.RandomWithPrefix("test-acc-scoped-repo")
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t); testAccPreCheckFeatureNotSupported(t, featureProjectScopedRepositories) },
-		ProviderFactories: testAccProviders,
-		Steps: []resource.TestStep{
-			// Create tests
-			{
-				Config:      testAccArgoCDRepositoryHelmProjectScoped(name),
-				ExpectError: regexp.MustCompile("repository project is only supported from ArgoCD"),
-			},
-			// Update tests (create repo without project, update it with project)
-			{
-				Config: testAccArgoCDRepositoryHelm(),
-				Check: resource.TestCheckResourceAttr(
-					"argocd_repository.helm",
-					"connection_state_status",
-					"Successful",
-				),
-			},
-			{
-				Config:      testAccArgoCDRepositoryHelmProjectScoped(name),
-				ExpectError: regexp.MustCompile("repository project is only supported from ArgoCD"),
 			},
 		},
 	})

--- a/argocd/server.go
+++ b/argocd/server.go
@@ -20,28 +20,8 @@ import (
 	"github.com/argoproj/argo-cd/v2/util/io"
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/oboukili/terraform-provider-argocd/internal/features"
 )
-
-const (
-	featureExecLogsPolicy = iota
-	featureProjectSourceNamespaces
-	featureMultipleApplicationSources
-	featureApplicationSet
-	featureApplicationSetProgressiveSync
-)
-
-type featureConstraint struct {
-	name       string
-	minVersion *semver.Version
-}
-
-var featureConstraintsMap = map[int]featureConstraint{
-	featureExecLogsPolicy:                {"exec/logs RBAC policy", semver.MustParse("2.4.4")},
-	featureProjectSourceNamespaces:       {"project source namespaces", semver.MustParse("2.5.0")},
-	featureMultipleApplicationSources:    {"multiple application sources", semver.MustParse("2.6.3")}, // Whilst the feature was introduced in 2.6.0 there was a bug that affects refresh of applications (and hence `wait` within this provider) that was only fixed in https://github.com/argoproj/argo-cd/pull/12576
-	featureApplicationSet:                {"application sets", semver.MustParse("2.5.0")},
-	featureApplicationSetProgressiveSync: {"progressive sync (`strategy`)", semver.MustParse("2.6.0")},
-}
 
 type ServerInterface struct {
 	AccountClient        account.AccountServiceClient
@@ -193,8 +173,8 @@ func (p *ServerInterface) initClients(ctx context.Context) error {
 
 // Checks that a specific feature is available for the current ArgoCD server version.
 // 'feature' argument must match one of the predefined feature* constants.
-func (p *ServerInterface) isFeatureSupported(feature int) bool {
-	fc, ok := featureConstraintsMap[feature]
+func (p *ServerInterface) isFeatureSupported(feature features.Feature) bool {
+	fc, ok := features.ConstraintsMap[feature]
 
-	return ok && fc.minVersion.Compare(p.ServerVersion) != 1
+	return ok && fc.MinVersion.Compare(p.ServerVersion) != 1
 }

--- a/argocd/server.go
+++ b/argocd/server.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/Masterminds/semver"
+	"github.com/Masterminds/semver/v3"
 	"github.com/argoproj/argo-cd/v2/pkg/apiclient"
 	"github.com/argoproj/argo-cd/v2/pkg/apiclient/account"
 	"github.com/argoproj/argo-cd/v2/pkg/apiclient/application"

--- a/argocd/server_test.go
+++ b/argocd/server_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/Masterminds/semver"
 	"github.com/argoproj/argo-cd/v2/pkg/apiclient/version"
+	"github.com/oboukili/terraform-provider-argocd/internal/features"
 	"github.com/stretchr/testify/assert"
 	"modernc.org/mathutil"
 )
@@ -62,7 +63,7 @@ func TestServerInterface_isFeatureSupported(t *testing.T) {
 	t.Parallel()
 
 	type args struct {
-		feature int
+		feature features.Feature
 	}
 
 	tests := []struct {
@@ -74,19 +75,19 @@ func TestServerInterface_isFeatureSupported(t *testing.T) {
 		{
 			name: "featureExecLogsPolicy-2.7.2",
 			si:   serverInterfaceTestData(t, "2.7.2", semverEquals),
-			args: args{feature: featureExecLogsPolicy},
+			args: args{feature: features.ExecLogsPolicy},
 			want: true,
 		},
 		{
 			name: "featureExecLogsPolicy-2.7.2+",
 			si:   serverInterfaceTestData(t, "2.7.2", semverGreater),
-			args: args{feature: featureExecLogsPolicy},
+			args: args{feature: features.ExecLogsPolicy},
 			want: true,
 		},
 		{
 			name: "featureExecLogsPolicy-2.7.2-",
 			si:   serverInterfaceTestData(t, "2.7.2", semverLess),
-			args: args{feature: featureExecLogsPolicy},
+			args: args{feature: features.ExecLogsPolicy},
 			want: false,
 		},
 	}

--- a/argocd/server_test.go
+++ b/argocd/server_test.go
@@ -2,14 +2,13 @@ package argocd
 
 import (
 	"fmt"
-	"math/rand"
 	"testing"
 
-	"github.com/Masterminds/semver"
+	"github.com/Masterminds/semver/v3"
 	"github.com/argoproj/argo-cd/v2/pkg/apiclient/version"
 	"github.com/oboukili/terraform-provider-argocd/internal/features"
 	"github.com/stretchr/testify/assert"
-	"modernc.org/mathutil"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -20,28 +19,22 @@ const (
 
 func serverInterfaceTestData(t *testing.T, argocdVersion string, semverOperator int) *ServerInterface {
 	v, err := semver.NewVersion(argocdVersion)
-	assert.NoError(t, err)
-
-	incPatch := rand.Int63n(100)
-	incMinor := rand.Int63n(100)
-	incMajor := rand.Int63n(100)
+	require.NoError(t, err)
+	require.True(t, v.Major() >= 1)
 
 	switch semverOperator {
 	case semverEquals:
 	case semverGreater:
-		v, err = semver.NewVersion(
-			fmt.Sprintf("%d.%d.%d",
-				v.Major()+incMajor,
-				v.Minor()+incMinor,
-				v.Patch()+incPatch,
-			))
+		inc := v.IncMajor()
+		v = &inc
+
 		assert.NoError(t, err)
 	case semverLess:
 		v, err = semver.NewVersion(
 			fmt.Sprintf("%d.%d.%d",
-				mathutil.MaxInt64(v.Major()-incMajor, 0),
-				mathutil.MaxInt64(v.Minor()-incMinor, 0),
-				mathutil.MaxInt64(v.Patch()-incPatch, 0),
+				v.Major()-1,
+				v.Minor(),
+				v.Patch(),
 			))
 		assert.NoError(t, err)
 	default:

--- a/argocd/structure_application_set.go
+++ b/argocd/structure_application_set.go
@@ -800,7 +800,8 @@ func expandApplicationSetTemplate(temp interface{}, featureMultipleApplicationSo
 			template.Spec.Source = &template.Spec.Sources[0]
 			template.Spec.Sources = nil
 		case l > 1 && !featureMultipleApplicationSourcesSupported:
-			return template, fmt.Errorf("multiple application sources is only supported from ArgoCD %s onwards", featureVersionConstraintsMap[featureMultipleApplicationSources].String())
+			f := featureConstraintsMap[featureMultipleApplicationSources]
+			return template, fmt.Errorf("%s is only supported from ArgoCD %s onwards", f.name, f.minVersion.String())
 		}
 	}
 

--- a/argocd/structure_application_set.go
+++ b/argocd/structure_application_set.go
@@ -7,6 +7,7 @@ import (
 
 	application "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/oboukili/terraform-provider-argocd/internal/features"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -800,8 +801,8 @@ func expandApplicationSetTemplate(temp interface{}, featureMultipleApplicationSo
 			template.Spec.Source = &template.Spec.Sources[0]
 			template.Spec.Sources = nil
 		case l > 1 && !featureMultipleApplicationSourcesSupported:
-			f := featureConstraintsMap[featureMultipleApplicationSources]
-			return template, fmt.Errorf("%s is only supported from ArgoCD %s onwards", f.name, f.minVersion.String())
+			f := features.ConstraintsMap[features.MultipleApplicationSources]
+			return template, fmt.Errorf("%s is only supported from ArgoCD %s onwards", f.Name, f.MinVersion.String())
 		}
 	}
 

--- a/argocd/structure_repository_credentials.go
+++ b/argocd/structure_repository_credentials.go
@@ -79,13 +79,7 @@ func flattenRepositoryCredentials(repoCreds application.RepoCreds, d *schema.Res
 
 	for k, v := range r {
 		if err := persistToState(k, v, d); err != nil {
-			return []diag.Diagnostic{
-				{
-					Severity: diag.Error,
-					Summary:  fmt.Sprintf("credentials key (%s) and value for repository %s could not be persisted to state", k, repoCreds.URL),
-					Detail:   err.Error(),
-				},
-			}
+			return errorToDiagnostics(fmt.Sprintf("credentials key (%s) and value for repository %s could not be persisted to state", k, repoCreds.URL), err)
 		}
 	}
 

--- a/argocd/utils.go
+++ b/argocd/utils.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/argoproj/argo-cd/v2/server/rbacpolicy"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -158,4 +159,15 @@ func persistToState(key string, data interface{}, d *schema.ResourceData) error 
 	}
 
 	return nil
+}
+
+func featureNotSupported(feature int) diag.Diagnostics {
+	f := featureConstraintsMap[feature]
+
+	return []diag.Diagnostic{
+		{
+			Severity: diag.Error,
+			Summary:  fmt.Sprintf("%s is only supported from ArgoCD %s onwards", f.name, f.minVersion.String()),
+		},
+	}
 }

--- a/argocd/utils.go
+++ b/argocd/utils.go
@@ -171,6 +171,19 @@ func argoCDAPIError(action, resource, id string, err error) diag.Diagnostics {
 	}
 }
 
+func errorToDiagnostics(summary string, err error) diag.Diagnostics {
+	d := diag.Diagnostic{
+		Severity: diag.Error,
+		Summary:  summary,
+	}
+
+	if err != nil {
+		d.Detail = err.Error()
+	}
+
+	return []diag.Diagnostic{d}
+}
+
 func featureNotSupported(feature int) diag.Diagnostics {
 	f := featureConstraintsMap[feature]
 

--- a/argocd/utils.go
+++ b/argocd/utils.go
@@ -9,6 +9,7 @@ import (
 	"github.com/argoproj/argo-cd/v2/server/rbacpolicy"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/oboukili/terraform-provider-argocd/internal/features"
 )
 
 func convertStringToInt64(s string) (i int64, err error) {
@@ -184,13 +185,13 @@ func errorToDiagnostics(summary string, err error) diag.Diagnostics {
 	return []diag.Diagnostic{d}
 }
 
-func featureNotSupported(feature int) diag.Diagnostics {
-	f := featureConstraintsMap[feature]
+func featureNotSupported(feature features.Feature) diag.Diagnostics {
+	f := features.ConstraintsMap[feature]
 
 	return []diag.Diagnostic{
 		{
 			Severity: diag.Error,
-			Summary:  fmt.Sprintf("%s is only supported from ArgoCD %s onwards", f.name, f.minVersion.String()),
+			Summary:  fmt.Sprintf("%s is only supported from ArgoCD %s onwards", f.Name, f.MinVersion.String()),
 		},
 	}
 }

--- a/argocd/utils.go
+++ b/argocd/utils.go
@@ -161,6 +161,16 @@ func persistToState(key string, data interface{}, d *schema.ResourceData) error 
 	return nil
 }
 
+func argoCDAPIError(action, resource, id string, err error) diag.Diagnostics {
+	return []diag.Diagnostic{
+		{
+			Severity: diag.Error,
+			Summary:  fmt.Sprintf("failed to %s %s %s", action, resource, id),
+			Detail:   err.Error(),
+		},
+	}
+}
+
 func featureNotSupported(feature int) diag.Diagnostics {
 	f := featureConstraintsMap[feature]
 

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,7 @@ module github.com/oboukili/terraform-provider-argocd
 go 1.19
 
 require (
-	github.com/Masterminds/semver v1.5.0
-	github.com/apparentlymart/go-cidr v1.1.0 // indirect
+	github.com/Masterminds/semver/v3 v3.2.1
 	github.com/argoproj/argo-cd/v2 v2.6.7
 	github.com/argoproj/gitops-engine v0.7.3
 	github.com/argoproj/pkg v0.13.7-0.20221221191914-44694015343d
@@ -19,12 +18,10 @@ require (
 	github.com/robfig/cron v1.2.0
 	github.com/stretchr/testify v1.8.1
 	golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa
+	k8s.io/apiextensions-apiserver v0.24.2
 	k8s.io/apimachinery v0.24.2
 	k8s.io/client-go v11.0.1-0.20190816222228-6d55c1b1f1ca+incompatible
-	modernc.org/mathutil v1.0.0
 )
-
-require k8s.io/apiextensions-apiserver v0.24.2
 
 require (
 	cloud.google.com/go v0.99.0 // indirect
@@ -38,7 +35,7 @@ require (
 	github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible // indirect
 	github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
-	github.com/Masterminds/semver/v3 v3.2.0 // indirect
+	github.com/Masterminds/semver v1.5.0 // indirect
 	github.com/Masterminds/sprig v2.22.0+incompatible // indirect
 	github.com/Masterminds/sprig/v3 v3.2.2 // indirect
 	github.com/Microsoft/go-winio v0.4.17 // indirect
@@ -50,6 +47,7 @@ require (
 	github.com/alicebob/gopher-json v0.0.0-20200520072559-a9ecdc9d1d3a // indirect
 	github.com/alicebob/miniredis/v2 v2.23.1 // indirect
 	github.com/antonmedv/expr v1.9.0 // indirect
+	github.com/apparentlymart/go-cidr v1.1.0 // indirect
 	github.com/apparentlymart/go-textseg/v13 v13.0.0 // indirect
 	github.com/argoproj/notifications-engine v0.3.1-0.20221203221941-490d98afd1d6 // indirect
 	github.com/armon/go-radix v1.0.0 // indirect
@@ -176,7 +174,6 @@ require (
 	github.com/prometheus/common v0.37.0 // indirect
 	github.com/prometheus/procfs v0.8.0 // indirect
 	github.com/r3labs/diff v1.1.0 // indirect
-	github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446 // indirect
 	github.com/robfig/cron/v3 v3.0.1 // indirect
 	github.com/rs/cors v1.8.0 // indirect
 	github.com/russross/blackfriday v1.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -85,8 +85,8 @@ github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy86
 github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
-github.com/Masterminds/semver/v3 v3.2.0 h1:3MEsd0SM6jqZojhjLWWeBY+Kcjy9i6MQAeY7YgDP83g=
-github.com/Masterminds/semver/v3 v3.2.0/go.mod h1:qvl/7zhW3nngYb5+80sSMF+FG2BjYrf8m9wsX0PNOMQ=
+github.com/Masterminds/semver/v3 v3.2.1 h1:RN9w6+7QoMeJVGyfmbcgs28Br8cvmnucEXnY0rYXWg0=
+github.com/Masterminds/semver/v3 v3.2.1/go.mod h1:qvl/7zhW3nngYb5+80sSMF+FG2BjYrf8m9wsX0PNOMQ=
 github.com/Masterminds/sprig v2.22.0+incompatible h1:z4yfnGrZ7netVz+0EDJ0Wi+5VZCSYp4Z0m2dk6cEM60=
 github.com/Masterminds/sprig v2.22.0+incompatible/go.mod h1:y6hNFY5UBTIWBxnzTeuNhlNS5hqE0NB0E6fgfo2Br3o=
 github.com/Masterminds/sprig/v3 v3.2.0/go.mod h1:tWhwTbUTndesPNeF0C900vKoq283u6zp4APT9vaF3SI=
@@ -994,7 +994,6 @@ github.com/quobyte/api v0.1.8/go.mod h1:jL7lIHrmqQ7yh05OJ+eEEdHr0u/kmT1Ff9iHd+4H
 github.com/r3labs/diff v1.1.0 h1:V53xhrbTHrWFWq3gI4b94AjgEJOerO1+1l0xyHOBi8M=
 github.com/r3labs/diff v1.1.0/go.mod h1:7WjXasNzi0vJetRcB/RqNl5dlIsmXcTTLmF5IoH6Xig=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
-github.com/remyoudompheng/bigfft v0.0.0-20220927061507-ef77025ab5aa h1:tEkEyxYeZ43TR55QU/hsIt9aRGBxbgGuz9CGykjvogY=
 github.com/remyoudompheng/bigfft v0.0.0-20220927061507-ef77025ab5aa/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rivo/tview v0.0.0-20200219210816-cd38d7432498/go.mod h1:6lkG1x+13OShEf0EaOCaTQYyB7d5nSbb181KtjlS+84=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
@@ -1905,7 +1904,6 @@ layeh.com/gopher-json v0.0.0-20190114024228-97fed8db8427 h1:RZkKxMR3jbQxdCEcglq3
 layeh.com/gopher-json v0.0.0-20190114024228-97fed8db8427/go.mod h1:ivKkcY8Zxw5ba0jldhZCYYQfGdb2K6u9tbYK1AwMIBc=
 modernc.org/cc v1.0.0/go.mod h1:1Sk4//wdnYJiUIxnW8ddKpaOJCF37yAdqYnkxUpaYxw=
 modernc.org/golex v1.0.0/go.mod h1:b/QX9oBD/LhixY6NDh+IdGv17hgB+51fET1i2kPSmvk=
-modernc.org/mathutil v1.0.0 h1:93vKjrJopTPrtTNpZ8XIovER7iCIH1QU7wNbOQXC60I=
 modernc.org/mathutil v1.0.0/go.mod h1:wU0vUrJsVWBZ4P6e7xtFJEhFSNsfRLJ8H458uRjg03k=
 modernc.org/strutil v1.0.0/go.mod h1:lstksw84oURvj9y3tn8lGvRxyRC1S2+g5uuIzNfIOBs=
 modernc.org/xc v1.0.0/go.mod h1:mRNCo0bvLjGhHO9WsyuKVU4q0ceiDDDoEeWDJHrNx8I=

--- a/internal/features/features.go
+++ b/internal/features/features.go
@@ -1,7 +1,7 @@
 package features
 
 import (
-	"github.com/Masterminds/semver"
+	"github.com/Masterminds/semver/v3"
 )
 
 type Feature int64

--- a/internal/features/features.go
+++ b/internal/features/features.go
@@ -1,0 +1,28 @@
+package features
+
+import (
+	"github.com/Masterminds/semver"
+)
+
+type Feature int64
+
+const (
+	ExecLogsPolicy Feature = iota
+	ProjectSourceNamespaces
+	MultipleApplicationSources
+	ApplicationSet
+	ApplicationSetProgressiveSync
+)
+
+type FeatureConstraint struct {
+	Name       string
+	MinVersion *semver.Version
+}
+
+var ConstraintsMap = map[Feature]FeatureConstraint{
+	ExecLogsPolicy:                {"exec/logs RBAC policy", semver.MustParse("2.4.4")},
+	ProjectSourceNamespaces:       {"project source namespaces", semver.MustParse("2.5.0")},
+	MultipleApplicationSources:    {"multiple application sources", semver.MustParse("2.6.3")}, // Whilst the feature was introduced in 2.6.0 there was a bug that affects refresh of applications (and hence `wait` within this provider) that was only fixed in https://github.com/argoproj/argo-cd/pull/12576
+	ApplicationSet:                {"application sets", semver.MustParse("2.5.0")},
+	ApplicationSetProgressiveSync: {"progressive sync (`strategy`)", semver.MustParse("2.6.0")},
+}


### PR DESCRIPTION
Simplifies error handling across all resources through the introduction of 3 utils methods (see related discussion [here](https://github.com/oboukili/terraform-provider-argocd/pull/278#discussion_r1204744146)):
- `featureNotSupported` - used to simplify error returned if a user makes use of configuration options that are not supported by their ArgoCD version
- `argoCDAPIError` - used to standardise error messages returned by the provider when handling errors returned by the ArgoCD API during CRUD operations
- `errorToDiagnostics` - provides a terser syntax to return an error message (and detail) when handling errors

**Note**: as part of this change, we are explicitly dropping feature "flags" for all unsupported versions of ArgoCD. In most cases, this won't affect consumers since, if they are using an outdated version of ArgoCD, then they would have received an error when trying to make use of newer configuration options. I.e. we can be confident that they are not making use of features that are not supported for their version of ArgoCD. However, there are two cases where, within the provider, we supported both old and new versions, whereas, from this point on, we will only support the _new_ versions. As such, anyone using the following resources and ArgoCD versions will need to ensure they upgrade their ArgoCD instance:
- `argocd_project_token` with ArgoCD version `<1.5.3`
- `argocd_repository` with ArgoCD version `<1.6.0`

Whilst this could be seen as a breaking change, my inclination is that, due to how outdated the ArgoCD versions are, we simply highlight this change with a warning in the release notes. 