### PR TITLE
Prevent permanent diff on `argocd_repository` with inherited credentials

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,7 +48,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        argocd_version: ["v2.5.0", "v2.5.17", "v2.6.0", "v2.6.8", "v2.7.3"]
+        argocd_version: ["v2.5.18", "v2.6.9", "v2.7.4"]
     steps:
       - name: Check out code
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0

--- a/argocd/structure_repository.go
+++ b/argocd/structure_repository.go
@@ -96,23 +96,30 @@ func flattenRepository(repository *application.Repository, d *schema.ResourceDat
 		"insecure":                repository.Insecure,
 		"name":                    repository.Name,
 		"project":                 repository.Project,
-		// TODO: in case of repositoryCredentials existence, will perma-diff
-		//"username":                		repository.Username,
-		// TODO: ArgoCD API does not return sensitive data!
-		//"password":                		repository.Password,
-		//"ssh_private_key":         		repository.SSHPrivateKey,
-		//"tls_client_cert_key":     		repository.TLSClientCertKey,
-		"tls_client_cert_data":          repository.TLSClientCertData,
-		"type":                          repository.Type,
-		"githubapp_enterprise_base_url": repository.GitHubAppEnterpriseBaseURL,
+		"type":                    repository.Type,
+
+		// ArgoCD API does not return sensitive data so we can't track the state of these attributes.
+		// "password":              repository.Password,
+		// "ssh_private_key":       repository.SSHPrivateKey,
+		// "tls_client_cert_key":   repository.TLSClientCertKey,
+		// "githubapp_private_key": repository.GithubAppPrivateKey,
 	}
 
-	if repository.GithubAppId > 0 {
-		r["githubapp_id"] = convertInt64ToString(repository.GithubAppId)
-	}
+	if !repository.InheritedCreds {
+		// To prevent perma-diff in case of existence of repository credentials
+		// existence, we only track the state of these values when the
+		// repository is not inheriting credentials
+		r["githubapp_enterprise_base_url"] = repository.GitHubAppEnterpriseBaseURL
+		r["tls_client_cert_data"] = repository.TLSClientCertData
+		r["username"] = repository.Username
 
-	if repository.GithubAppInstallationId > 0 {
-		r["githubapp_installation_id"] = convertInt64ToString(repository.GithubAppInstallationId)
+		if repository.GithubAppId > 0 {
+			r["githubapp_id"] = convertInt64ToString(repository.GithubAppId)
+		}
+
+		if repository.GithubAppInstallationId > 0 {
+			r["githubapp_installation_id"] = convertInt64ToString(repository.GithubAppInstallationId)
+		}
 	}
 
 	for k, v := range r {


### PR DESCRIPTION
Closes #270

Dependent on https://github.com/argoproj/argo-cd/pull/13428, which will be contained in the next set of patch releases for `2.5.x`->`2.7.x` (due for release shortly). Once this happens, I will bump the build/test versions, which should resolve the current failures. Similarly, consumers will need to update to those patches to prevent the same perma-diff being introduced on `username` due to this change.