### PR TITLE
Prevent permanent diff on `argocd_cluster` with sensitive attributes

### DIFF
--- a/argocd/resource_argocd_cluster_test.go
+++ b/argocd/resource_argocd_cluster_test.go
@@ -48,13 +48,12 @@ func TestAccArgoCDCluster(t *testing.T) {
 					),
 				),
 			},
-			// TODO: not working on CI every time
-			// {
-			// 	ResourceName:            "argocd_cluster.simple",
-			// 	ImportState:             true,
-			// 	ImportStateVerify:       true,
-			// 	ImportStateVerifyIgnore: []string{"config.0.bearer_token", "config.0.tls_client_config"},
-			// },
+			{
+				ResourceName:            "argocd_cluster.simple",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"config.0.bearer_token"},
+			},
 			{
 				Config: testAccArgoCDClusterTLSCertificate(t, acctest.RandString(10)),
 				Check: resource.ComposeTestCheckFunc(
@@ -104,13 +103,12 @@ func TestAccArgoCDCluster_projectScope(t *testing.T) {
 					),
 				),
 			},
-			// TODO: not working on CI every time
-			// {
-			// 	ResourceName:            "argocd_cluster.project_scope",
-			// 	ImportState:             true,
-			// 	ImportStateVerify:       true,
-			// 	ImportStateVerifyIgnore: []string{"config.0.bearer_token", "config.0.tls_client_config"},
-			// },
+			{
+				ResourceName:            "argocd_cluster.project_scope",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"config.0.bearer_token"},
+			},
 		},
 	})
 }
@@ -206,7 +204,7 @@ func TestAccArgoCDCluster_metadata(t *testing.T) {
 				ResourceName:            "argocd_cluster.cluster_metadata",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"config", "info"},
+				ImportStateVerifyIgnore: []string{"config.0.bearer_token", "info"},
 			},
 			{
 				Config: testAccArgoCDClusterMetadata_addLabels(clusterName),
@@ -226,7 +224,7 @@ func TestAccArgoCDCluster_metadata(t *testing.T) {
 				ResourceName:            "argocd_cluster.cluster_metadata",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"config", "info"},
+				ImportStateVerifyIgnore: []string{"config.0.bearer_token", "info"},
 			},
 			{
 				Config: testAccArgoCDClusterMetadata_addAnnotations(clusterName),
@@ -247,7 +245,7 @@ func TestAccArgoCDCluster_metadata(t *testing.T) {
 				ResourceName:            "argocd_cluster.cluster_metadata",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"config", "info"},
+				ImportStateVerifyIgnore: []string{"config.0.bearer_token", "info"},
 			},
 			{
 				Config: testAccArgoCDClusterMetadata_removeLabels(clusterName),
@@ -267,7 +265,7 @@ func TestAccArgoCDCluster_metadata(t *testing.T) {
 				ResourceName:            "argocd_cluster.cluster_metadata",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"config", "info"},
+				ImportStateVerifyIgnore: []string{"config.0.bearer_token", "info"},
 			},
 		},
 	})

--- a/argocd/schema_cluster.go
+++ b/argocd/schema_cluster.go
@@ -88,6 +88,7 @@ func clusterSchema() map[string]*schema.Schema {
 									Type:        schema.TypeList,
 									Optional:    true,
 									Description: "Arguments to pass to the command when executing it",
+									Sensitive:   true,
 									Elem: &schema.Schema{
 										Type: schema.TypeString,
 									},
@@ -101,6 +102,7 @@ func clusterSchema() map[string]*schema.Schema {
 									Type:        schema.TypeMap,
 									Optional:    true,
 									Description: "Env defines additional environment variables to expose to the process. Passed as a map of strings",
+									Sensitive:   true,
 									Elem: &schema.Schema{
 										Type: schema.TypeString,
 									},

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -166,9 +166,9 @@ Optional:
 Optional:
 
 - `api_version` (String) Preferred input version of the ExecInfo
-- `args` (List of String) Arguments to pass to the command when executing it
+- `args` (List of String, Sensitive) Arguments to pass to the command when executing it
 - `command` (String) Command to execute
-- `env` (Map of String) Env defines additional environment variables to expose to the process. Passed as a map of strings
+- `env` (Map of String, Sensitive) Env defines additional environment variables to expose to the process. Passed as a map of strings
 - `install_hint` (String) This text is shown to the user when the executable doesn't seem to be present
 
 


### PR DESCRIPTION
This change ensures that the `argocd_cluster` resource won't perma-diff on sensitive attributes whilst, at the same time, ensuring that we track the remote state for non-sensitive attributes that are returned by the API (see comment inline). 

Closes #297