### PR TITLE
Add support for timezone in sync window

### DIFF
--- a/argocd/resource_argocd_account_token_test.go
+++ b/argocd/resource_argocd_account_token_test.go
@@ -138,8 +138,7 @@ func TestAccArgoCDAccountToken_RenewBefore(t *testing.T) {
 
 func TestAccArgoCDAccountToken_RenewAfter(t *testing.T) {
 	resourceName := "argocd_account_token.renew_after"
-
-	renewAfterSeconds := 2
+	renewAfterSeconds := 30
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },

--- a/argocd/resource_argocd_cluster_test.go
+++ b/argocd/resource_argocd_cluster_test.go
@@ -52,7 +52,7 @@ func TestAccArgoCDCluster(t *testing.T) {
 				ResourceName:            "argocd_cluster.simple",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"config.0.bearer_token"},
+				ImportStateVerifyIgnore: []string{"config.0.bearer_token", "info"},
 			},
 			{
 				Config: testAccArgoCDClusterTLSCertificate(t, acctest.RandString(10)),
@@ -107,7 +107,7 @@ func TestAccArgoCDCluster_projectScope(t *testing.T) {
 				ResourceName:            "argocd_cluster.project_scope",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"config.0.bearer_token"},
+				ImportStateVerifyIgnore: []string{"config.0.bearer_token", "info"},
 			},
 		},
 	})

--- a/argocd/resource_argocd_project_test.go
+++ b/argocd/resource_argocd_project_test.go
@@ -338,7 +338,7 @@ resource "argocd_project" "simple" {
       duration = "12h"
       schedule = "22 1 5 * *"
       manual_sync = false
-			timezone = "Europe/London"
+      timezone = "Europe/London"
     }
     signature_keys = [
       "4AEE18F83AFDEB23",
@@ -810,17 +810,17 @@ resource "argocd_project" "failure" {
   spec {
     description = "expected timezone failure"
     destination {
-	   server    = "https://kubernetes.default.svc"
-	   namespace = "*"
+      server    = "https://kubernetes.default.svc"
+      namespace = "*"
     }
     source_repos = ["*"]
     role {
       name = "incorrect-syncwindow"
       policies = [
-        "p, proj:%s:testrole, applications, override, %s/foo, allow",
+      "p, proj:%s:testrole, applications, override, %s/foo, allow",
       ]
     }
-	sync_window {
+    sync_window {
       kind = "allow"
       applications = ["api-*"]
       clusters = ["*"]
@@ -828,7 +828,7 @@ resource "argocd_project" "failure" {
       duration = "1h"
       schedule = "10 1 * * *"
       manual_sync = true
-    	timezone = "invalid"
+      timezone = "invalid"
     }
   }
 }

--- a/argocd/resource_argocd_project_test.go
+++ b/argocd/resource_argocd_project_test.go
@@ -48,6 +48,12 @@ func TestAccArgoCDProject(t *testing.T) {
 				ExpectError: regexp.MustCompile("cannot parse schedule"),
 			},
 			{
+				Config: testAccArgoCDProjectSyncWindowTimezoneError(
+					"test-acc-" + acctest.RandString(10),
+				),
+				ExpectError: regexp.MustCompile("cannot parse timezone"),
+			},
+			{
 				Config: testAccArgoCDProjectSimple(name),
 				Check: resource.TestCheckResourceAttrSet(
 					"argocd_project.simple",
@@ -332,6 +338,7 @@ resource "argocd_project" "simple" {
       duration = "12h"
       schedule = "22 1 5 * *"
       manual_sync = false
+			timezone = "Europe/London"
     }
     signature_keys = [
       "4AEE18F83AFDEB23",
@@ -790,4 +797,40 @@ resource "argocd_project" "simple" {
   }
 }
 	`, name)
+}
+
+func testAccArgoCDProjectSyncWindowTimezoneError(name string) string {
+	return fmt.Sprintf(`
+resource "argocd_project" "failure" {
+  metadata {
+    name        = "%s"
+    namespace   = "argocd"
+  }
+
+  spec {
+    description = "expected timezone failure"
+    destination {
+	   server    = "https://kubernetes.default.svc"
+	   namespace = "*"
+    }
+    source_repos = ["*"]
+    role {
+      name = "incorrect-syncwindow"
+      policies = [
+        "p, proj:%s:testrole, applications, override, %s/foo, allow",
+      ]
+    }
+	sync_window {
+      kind = "allow"
+      applications = ["api-*"]
+      clusters = ["*"]
+      namespaces = ["*"]
+      duration = "1h"
+      schedule = "10 1 * * *"
+      manual_sync = true
+    	timezone = "invalid"
+    }
+  }
+}
+  `, name, name, name)
 }

--- a/argocd/resource_argocd_project_token_test.go
+++ b/argocd/resource_argocd_project_token_test.go
@@ -109,8 +109,7 @@ func TestAccArgoCDProjectToken_RenewBefore(t *testing.T) {
 
 func TestAccArgoCDProjectToken_RenewAfter(t *testing.T) {
 	resourceName := "argocd_project_token.renew_after"
-
-	renewAfterSeconds := 2
+	renewAfterSeconds := 30
 
 	// Note: not running in parallel as this is a time sensitive test case
 	resource.Test(t, resource.TestCase{

--- a/argocd/schema_project.go
+++ b/argocd/schema_project.go
@@ -665,6 +665,13 @@ func projectSpecSchemaV2() *schema.Schema {
 								ValidateFunc: validateSyncWindowSchedule,
 								Optional:     true,
 							},
+							"timezone": {
+								Type:         schema.TypeString,
+								Description:  "Timezone that the schedule will be evaluated in.",
+								ValidateFunc: validateSyncWindowTimezone,
+								Optional:     true,
+								Default:      "UTC",
+							},
 						},
 					},
 				},

--- a/argocd/structure_application.go
+++ b/argocd/structure_application.go
@@ -516,6 +516,7 @@ func expandSyncWindows(sws []interface{}) (result []*application.SyncWindow) {
 			ManualSync:   sw["manual_sync"].(bool),
 			Namespaces:   expandStringList(sw["namespaces"].([]interface{})),
 			Schedule:     sw["schedule"].(string),
+			TimeZone:     sw["timezone"].(string),
 		})
 	}
 

--- a/argocd/structures.go
+++ b/argocd/structures.go
@@ -97,6 +97,7 @@ func flattenSyncWindows(sws application.SyncWindows) (result []map[string]interf
 			"manual_sync":  sw.ManualSync,
 			"namespaces":   sw.Namespaces,
 			"schedule":     sw.Schedule,
+			"timezone":     sw.TimeZone,
 		})
 	}
 

--- a/argocd/validators.go
+++ b/argocd/validators.go
@@ -4,8 +4,10 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"time"
+	_ "time/tzdata"
 
-	"github.com/argoproj/pkg/time"
+	argocdtime "github.com/argoproj/pkg/time"
 	"github.com/robfig/cron"
 	"golang.org/x/crypto/ssh"
 	apiValidation "k8s.io/apimachinery/pkg/api/validation"
@@ -105,8 +107,17 @@ func validateSyncWindowSchedule(value interface{}, key string) (ws []string, es 
 func validateSyncWindowDuration(value interface{}, key string) (ws []string, es []error) {
 	v := value.(string)
 
-	if _, err := time.ParseDuration(v); err != nil {
+	if _, err := argocdtime.ParseDuration(v); err != nil {
 		es = append(es, fmt.Errorf("%s: cannot parse duration '%s': %s", key, v, err))
+	}
+
+	return
+}
+
+func validateSyncWindowTimezone(value interface{}, key string) (ws []string, es []error) {
+	v := value.(string)
+	if _, err := time.LoadLocation(v); err != nil {
+		es = append(es, fmt.Errorf("%s: cannot parse timezone '%s': %s", key, v, err))
 	}
 
 	return

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -120,6 +120,7 @@ resource "argocd_project" "myproject" {
       duration     = "12h"
       schedule     = "22 1 5 * *"
       manual_sync  = false
+      timezone     = "Europe/London"
     }
 
     signature_keys = [
@@ -274,6 +275,7 @@ Optional:
 - `manual_sync` (Boolean) Enables manual syncs when they would otherwise be blocked.
 - `namespaces` (List of String) List of namespaces that the window will apply to.
 - `schedule` (String) Time the window will begin, specified in cron format.
+- `timezone` (String) Timezone that the schedule will be evaluated in.
 
 ## Import
 

--- a/examples/resources/argocd_project/resource.tf
+++ b/examples/resources/argocd_project/resource.tf
@@ -105,6 +105,7 @@ resource "argocd_project" "myproject" {
       duration     = "12h"
       schedule     = "22 1 5 * *"
       manual_sync  = false
+      timezone     = "Europe/London"
     }
 
     signature_keys = [

--- a/manifests/local-dev/project.tf
+++ b/manifests/local-dev/project.tf
@@ -79,6 +79,7 @@ resource "argocd_project" "foo" {
       duration     = "12h"
       schedule     = "22 1 5 * *"
       manual_sync  = false
+      timezone     = "Europe/London"
     }
   }
 }


### PR DESCRIPTION
Whilst the ArgoCD API now supports setting the timezone in a project's sync window, the provider does not expose this so I have had to set it manually. This change exposes the timezone capability in the provider so that it can be configured via Terraform.
