### PR TITLE
feat(argocd_application_set): Add support for pathParamPrefix

### DIFF
--- a/argocd/schema_application_set.go
+++ b/argocd/schema_application_set.go
@@ -286,6 +286,11 @@ func applicationSetGitGeneratorSchemaV0() *schema.Schema {
 					Description: "Revision of the source repository to use.",
 					Optional:    true,
 				},
+				"path_param_prefix": {
+					Type:        schema.TypeString,
+					Description: "Prefix for all path-related parameter names.",
+					Optional:    true,
+				},
 				"template": {
 					Type:        schema.TypeList,
 					Description: "Generator template. Used to override the values of the spec-level template.",

--- a/argocd/structure_application_set.go
+++ b/argocd/structure_application_set.go
@@ -199,6 +199,10 @@ func expandApplicationSetGitGenerator(gg interface{}, featureMultipleApplication
 		}
 	}
 
+	if v, ok := g["path_param_prefix"].(string); ok && len(v) > 0 {
+		asg.Git.PathParamPrefix = v
+	}
+
 	if v, ok := g["template"].([]interface{}); ok && len(v) > 0 {
 		temp, err := expandApplicationSetTemplate(v[0], featureMultipleApplicationSourcesSupported)
 		if err != nil {


### PR DESCRIPTION
Fixes [(#329)](https://github.com/oboukili/terraform-provider-argocd/issues/329).

This PR adds support for the pathParamPrefix parameter in the git generator.

