### PR TITLE
fix(argocd_application): don't flatten `spec.info` if list is empty

### DIFF
--- a/argocd/structure_application.go
+++ b/argocd/structure_application.go
@@ -634,7 +634,9 @@ func flattenApplicationInfo(infos []application.Info) (result []map[string]strin
 			info["value"] = i.Value
 		}
 
-		result = append(result, info)
+		if len(info) > 0 {
+			result = append(result, info)
+		}
 	}
 
 	return


### PR DESCRIPTION
Fixes #277

Seems to be an edge case of:
- #168

/cc: @onematchfox , @MrLuje