### PR TITLE
fix: Add DiffSuppressFunc on argocd_cluster.server

### DIFF
--- a/argocd/schema_cluster.go
+++ b/argocd/schema_cluster.go
@@ -2,6 +2,7 @@ package argocd
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"strings"
 )
 
 func clusterSchema() map[string]*schema.Schema {
@@ -26,6 +27,9 @@ func clusterSchema() map[string]*schema.Schema {
 			Type:        schema.TypeString,
 			Description: "Server is the API server URL of the Kubernetes cluster.",
 			Optional:    true,
+			DiffSuppressFunc: func(k, oldValue, newValue string, d *schema.ResourceData) bool {
+				return oldValue == strings.TrimRight(newValue, "/")
+			},
 		},
 		"shard": {
 			Type:        schema.TypeString,


### PR DESCRIPTION
While working on this PR here:
- #349

, I saw that the build is already broken on `master` branch:
![image](https://github.com/oboukili/terraform-provider-argocd/assets/7290987/c8afc1f0-4825-4d5e-98b3-6754ce7cc54b)


It seems that the test is failing due to inconsistent handling of a trailing `/`.

```log
=== RUN   TestAccArgoCDCluster_invalidSameServer
    resource_argocd_cluster_test.go:275: Step 3/3, expected an error with pattern, no match on: After applying this test step, the plan was not empty.
        stdout:
        
        
        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
          ~ update in-place
        
        Terraform will perform the following actions:
        
          # argocd_cluster.cluster_with_trailing_slash will be updated in-place
          ~ resource "argocd_cluster" "cluster_with_trailing_slash" {
                id     = "https://kubernetes.default.svc.cluster.local/server"
                name   = "server"
              ~ server = "https://kubernetes.default.svc.cluster.local/" -> "https://kubernetes.default.svc.cluster.local/"
                # (1 unchanged attribute hidden)
        
                # (1 unchanged block hidden)
            }
        
        Plan: 0 to add, 1 to change, 0 to destroy.
    testing_new.go:82: Error running post-test destroy, there may be dangling resources: exit status 1
        
        Error: failed to delete cluster https://kubernetes.default.svc.cluster.local/server
        
        rpc error: code = PermissionDenied desc = permission denied
```

I am not familiar with the provider internals here but it seems that putting a diff-ignore function could help here. It is already present on the cluster create function:
https://github.com/oboukili/terraform-provider-argocd/blob/b42b92267a212b108537caf32a462c133f21813d/argocd/resource_argocd_cluster.go#L55

FYI @onematchfox 