### PR TITLE
Fix go version in release workflow and bump step versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
         fetch-depth: 0
 
     - name: Set up Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
         go-version: 1.19
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.19
+        go-version-file: 'go.mod'
 
     - name: Import GPG key
       id: import_gpg

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Set up Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
         go-version-file: 'go.mod'
       id: go
@@ -54,7 +54,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
           check-latest: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
       id: go
       
     - name: Run linters
-      uses: golangci/golangci-lint-action@08e2f20817b15149a52b5b3ebe7de50aff2ba8c5 # v3.4.0
+      uses: golangci/golangci-lint-action@v4
       with:
         version: v1.51.2
 


### PR DESCRIPTION
Still fighting to unblock releases of this repository :weary: 

`release` workflow was explicitly using go version `1.19` which is causing the pipeline to [fail](https://github.com/oboukili/terraform-provider-argocd/actions/runs/8403053068/job/23013137436) as we now require [go `1.20`](https://github.com/oboukili/terraform-provider-argocd/blob/ea02a51e1ec7cfceb36ec2e89baadeebef51e546/go.mod#L3). 

Other version bumps resolve [deprecation warnings](https://github.com/oboukili/terraform-provider-argocd/actions/runs/8402768584) due to use of Node 16.x.