### PR TITLE
fix(provider): ensure `ServerName` and `PortForwardNamespace` are set on `ClientOptions` when port forwarding

### DIFF
--- a/internal/provider/model_provider.go
+++ b/internal/provider/model_provider.go
@@ -236,6 +236,11 @@ func (p ArgoCDProviderConfig) setPortForwardingOpts(ctx context.Context, opts *a
 		}
 
 		opts.ServerAddr = "localhost" // will be overwritten by ArgoCD module when we initialize the API client but needs to be set here to ensure we
+		opts.ServerName = "argocd-server"
+
+		if opts.PortForwardNamespace == "" {
+			opts.PortForwardNamespace = "argocd"
+		}
 
 		if p.Kubernetes == nil {
 			break


### PR DESCRIPTION
Configuring the provider with port forwarding is currently broken in `v6.1.0` due to changes introduced in https://github.com/argoproj/argo-cd/pull/14605. That PR introduced the requirement to set both `ServerName` and `PortForwardNamespace` when making use of port forwarding.

At present, `v6.1.0` will fail with the following error as we are not setting these values.

```
╷
│ Error: failed to create new API client
│ 
│   with argocd_repository.this,
│   on repository.tf line 1, in resource "argocd_repository" "this":
│    1: resource "argocd_repository" "this" {
│ 
│ cannot find pod with selector: [app.kubernetes.io/name=] - use the --{component}-name flag in this command or set the environmental variable (Refer to
│ https://argo-cd.readthedocs.io/en/stable/user-guide/environment-variables), to change the Argo CD component name in the CLI
╵
```

This PR ensures that we set both of these values. 