### PR TITLE
feat: add config & docs for easier contributing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,10 +2,13 @@ terraform-provider-argocd
 /manifests/install/argocd.yml
 /bin
 .idea
-.vscode
+
 # Env variables settings
 /scripts/testacc
 /scripts/testacc_prepare_env
 
 # debug build
-__debug_bin
+__debug_bin*
+
+# local reproduction folders
+reproduce/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,38 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Debug Terraform Provider",
+      "type": "go",
+      "request": "launch",
+      "mode": "debug",
+      "program": "${workspaceFolder}",
+      "env": {},
+      "args": [
+        "-debug"
+      ]
+    },
+    {
+      "name": "Debug Selected Test",
+      "request": "launch",
+      "type": "go",
+      "args": [
+        "-test.v",
+        "-test.run",
+        "^${selectedText}$"
+      ],
+      "mode": "auto",
+      "program": "${fileDirname}",
+      "env": {
+        "PKG_NAME": "${relativeFileDirname}",
+        "TF_ACC": "1",
+        "TF_LOG": "info",
+        "ARGOCD_INSECURE": "true",
+        "ARGOCD_SERVER": "127.0.0.1:8080",
+        "ARGOCD_AUTH_USERNAME": "admin",
+        "ARGOCD_AUTH_PASSWORD": "acceptancetesting"
+      },
+      "showLog": true
+    }
+  ]
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,6 +53,22 @@ Then, setup your environment following [these
 instructions](https://www.terraform.io/plugin/debugging#terraform-cli-development-overrides)
 to make your local terraform use your local build.
 
+## Debugging
+
+Hasicorp Docs: https://developer.hashicorp.com/terraform/plugin/debugging#starting-a-provider-in-debug-mode
+
+### Running the Terraform provider in debug mode
+
+In VS Code open the Debug tab and select the profile "Debug Terraform Provider". Set some breakpoints and then run this task. 
+
+Then head to the debug console and copy the line where it says `TF_REATTACH_PROVIDERS` and copy it.
+
+Now that your provider is running in debug-mode in VS Code, you can head to any terminal where you want to run a Terraform stack and prepend the terraform command with the copied text. The Terraform CLI will then ensure it's using the provider already running inside VS Code.
+
+### Running acceptance tests in debug mode
+
+Open a test file, hover over a test function name and in the Debug tab hit "Debug selected Test". You shouldn't use the builtin "Debug Test" profile that is shown when hovering over a test function since it doesn't contain the necessary configuration to find your Argo CD environment.
+
 ## Troubleshooting during local development
 
 * **"too many open files":** Running all acceptance tests in parallel (the


### PR DESCRIPTION
I find it tedious to ensure I have the proper debug config at hand. Thus managing it via Code would be awesome, so this PR adds the necessary `launch.json` vor VS Code.

Also it explains how to run the provider in debug-mode locally.