### PR TITLE
chore(goreleaser): change release notes format to Github's standard

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -43,7 +43,4 @@ release:
     owner: argoproj-labs
     name: terraform-provider-argocd
 changelog:
-  filters:
-    exclude:
-      - "^docs:"
-      - "^chore"
+  use: github-native


### PR DESCRIPTION
**What type of PR is this?**

[//]: # (Uncomment only one <!-- /kind ... --> line, and delete the rest.)
[//]: # (For example, <!-- /kind bug --> would simply become: /kind bug  )

/kind chore
<!-- /kind bug -->
<!-- /kind chore -->
<!-- /kind cleanup -->
<!-- /kind failing-test -->
<!-- /kind enhancement -->
<!-- /kind documentation -->
<!-- /kind code-refactoring -->


**What does this PR do / why we need it**:

Changes the release notes format for new releases to use Github's style.

Since most past releases changed them to this format manually after the release got initially published why not do it automatically?

See https://goreleaser.com/customization/changelog/ for all the options there are.
**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #?

**How to test changes / Special notes to the reviewer**: