### PR TITLE
fix: set computed on namespace field

### DIFF
--- a/docs/data-sources/application.md
+++ b/docs/data-sources/application.md
@@ -39,7 +39,7 @@ data "argocd_application" "foo" {
 
 Required:
 
-- `name` (String) Name of the applications.argoproj.io, must be unique. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names
+- `name` (String) Name of the applications.argoproj.io, must be unique. Cannot be updated. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
 
 Optional:
 
@@ -47,11 +47,11 @@ Optional:
 
 Read-Only:
 
-- `annotations` (Map of String) An unstructured key value map stored with the cluster secret that may be used to store arbitrary metadata. More info: http://kubernetes.io/docs/user-guide/annotations
+- `annotations` (Map of String) An unstructured key value map stored with the applications.argoproj.io that may be used to store arbitrary metadata. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
 - `generation` (Number) A sequence number representing a specific generation of the desired state.
-- `labels` (Map of String) Map of string keys and values that can be used to organize and categorize (scope and select) the cluster secret. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels
-- `resource_version` (String) An opaque value that represents the internal version of this applications.argoproj.io that can be used by clients to determine when applications.argoproj.io has changed. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
-- `uid` (String) The unique in time and space value for this applications.argoproj.io. More info: http://kubernetes.io/docs/user-guide/identifiers#uids
+- `labels` (Map of String) Map of string keys and values that can be used to organize and categorize (scope and select) the applications.argoproj.io. May match selectors of replication controllers and services. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels
+- `resource_version` (String) An opaque value that represents the internal version of this applications.argoproj.io that can be used by clients to determine when the applications.argoproj.io has changed. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+- `uid` (String) The unique in time and space value for this applications.argoproj.io. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
 
 
 <a id="nestedatt--spec"></a>

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -148,19 +148,19 @@ resource "argocd_project" "myproject" {
 
 Required:
 
-- `name` (String) Name of the appproject, must be unique. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names
+- `name` (String) Name of the appproject, must be unique. Cannot be updated. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
 
 Optional:
 
-- `annotations` (Map of String) An unstructured key value map stored with the cluster secret that may be used to store arbitrary metadata. More info: http://kubernetes.io/docs/user-guide/annotations
-- `labels` (Map of String) Map of string keys and values that can be used to organize and categorize (scope and select) the cluster secret. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels
+- `annotations` (Map of String) An unstructured key value map stored with the appproject that may be used to store arbitrary metadata. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+- `labels` (Map of String) Map of string keys and values that can be used to organize and categorize (scope and select) the appproject. May match selectors of replication controllers and services. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels
 - `namespace` (String) Namespace of the appproject, must be unique. Cannot be updated. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
 
 Read-Only:
 
 - `generation` (Number) A sequence number representing a specific generation of the desired state.
-- `resource_version` (String) An opaque value that represents the internal version of this appproject that can be used by clients to determine when appproject has changed. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
-- `uid` (String) The unique in time and space value for this appproject. More info: http://kubernetes.io/docs/user-guide/identifiers#uids
+- `resource_version` (String) An opaque value that represents the internal version of this appproject that can be used by clients to determine when the appproject has changed. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+- `uid` (String) The unique in time and space value for this appproject. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
 
 
 <a id="nestedblock--spec"></a>

--- a/internal/provider/model_metadata.go
+++ b/internal/provider/model_metadata.go
@@ -31,7 +31,7 @@ func objectMetaSchemaAttribute(objectName string, computed bool) schema.Attribut
 		Required:            true,
 		Attributes: map[string]schema.Attribute{
 			"name": schema.StringAttribute{
-				MarkdownDescription: fmt.Sprintf("Name of the %s, must be unique. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names", objectName),
+				MarkdownDescription: fmt.Sprintf("Name of the %s, must be unique. Cannot be updated. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names", objectName),
 				Required:            true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
@@ -52,7 +52,7 @@ func objectMetaSchemaAttribute(objectName string, computed bool) schema.Attribut
 				},
 			},
 			"annotations": schema.MapAttribute{
-				MarkdownDescription: "An unstructured key value map stored with the cluster secret that may be used to store arbitrary metadata. More info: http://kubernetes.io/docs/user-guide/annotations",
+				MarkdownDescription: fmt.Sprintf("An unstructured key value map stored with the %s that may be used to store arbitrary metadata. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/", objectName),
 				Computed:            computed,
 				Optional:            !computed,
 				ElementType:         types.StringType,
@@ -61,7 +61,7 @@ func objectMetaSchemaAttribute(objectName string, computed bool) schema.Attribut
 				},
 			},
 			"labels": schema.MapAttribute{
-				MarkdownDescription: "Map of string keys and values that can be used to organize and categorize (scope and select) the cluster secret. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels",
+				MarkdownDescription: fmt.Sprintf("Map of string keys and values that can be used to organize and categorize (scope and select) the %s. May match selectors of replication controllers and services. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels", objectName),
 				Computed:            computed,
 				Optional:            !computed,
 				ElementType:         types.StringType,
@@ -74,18 +74,18 @@ func objectMetaSchemaAttribute(objectName string, computed bool) schema.Attribut
 				Computed:            true,
 			},
 			"resource_version": schema.StringAttribute{
-				MarkdownDescription: fmt.Sprintf("An opaque value that represents the internal version of this %s that can be used by clients to determine when %s has changed. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency", objectName, objectName),
+				MarkdownDescription: fmt.Sprintf("An opaque value that represents the internal version of this %s that can be used by clients to determine when the %s has changed. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency", objectName, objectName),
 				Computed:            true,
 			},
 			"uid": schema.StringAttribute{
-				MarkdownDescription: fmt.Sprintf("The unique in time and space value for this %s. More info: http://kubernetes.io/docs/user-guide/identifiers#uids", objectName),
+				MarkdownDescription: fmt.Sprintf("The unique in time and space value for this %s. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids", objectName),
 				Computed:            true,
 			},
 		},
 	}
 }
 
-func objectMetaSchemaListBlock(objectName string, computed bool) schema.Block {
+func objectMetaSchemaListBlock(objectName string) schema.Block {
 	return schema.ListNestedBlock{
 		MarkdownDescription: "Standard Kubernetes object metadata. For more info see the [Kubernetes reference](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata).",
 		Validators: []validator.List{
@@ -96,7 +96,7 @@ func objectMetaSchemaListBlock(objectName string, computed bool) schema.Block {
 		NestedObject: schema.NestedBlockObject{
 			Attributes: map[string]schema.Attribute{
 				"name": schema.StringAttribute{
-					MarkdownDescription: fmt.Sprintf("Name of the %s, must be unique. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names", objectName),
+					MarkdownDescription: fmt.Sprintf("Name of the %s, must be unique. Cannot be updated. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names", objectName),
 					Required:            true,
 					PlanModifiers: []planmodifier.String{
 						stringplanmodifier.RequiresReplace(),
@@ -108,7 +108,7 @@ func objectMetaSchemaListBlock(objectName string, computed bool) schema.Block {
 				"namespace": schema.StringAttribute{
 					MarkdownDescription: fmt.Sprintf("Namespace of the %s, must be unique. Cannot be updated. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/", objectName),
 					Optional:            true,
-					Computed:            computed,
+					Computed:            true,
 					PlanModifiers: []planmodifier.String{
 						stringplanmodifier.RequiresReplace(),
 					},
@@ -117,18 +117,16 @@ func objectMetaSchemaListBlock(objectName string, computed bool) schema.Block {
 					},
 				},
 				"annotations": schema.MapAttribute{
-					MarkdownDescription: "An unstructured key value map stored with the cluster secret that may be used to store arbitrary metadata. More info: http://kubernetes.io/docs/user-guide/annotations",
-					Computed:            computed,
-					Optional:            !computed,
+					MarkdownDescription: fmt.Sprintf("An unstructured key value map stored with the %s that may be used to store arbitrary metadata. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/", objectName),
+					Optional:            true,
 					ElementType:         types.StringType,
 					Validators: []validator.Map{
 						validators.MetadataAnnotations(),
 					},
 				},
 				"labels": schema.MapAttribute{
-					MarkdownDescription: "Map of string keys and values that can be used to organize and categorize (scope and select) the cluster secret. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels",
-					Computed:            computed,
-					Optional:            !computed,
+					MarkdownDescription: fmt.Sprintf("Map of string keys and values that can be used to organize and categorize (scope and select) the %s. May match selectors of replication controllers and services. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels", objectName),
+					Optional:            true,
 					ElementType:         types.StringType,
 					Validators: []validator.Map{
 						validators.MetadataLabels(),
@@ -139,11 +137,11 @@ func objectMetaSchemaListBlock(objectName string, computed bool) schema.Block {
 					Computed:            true,
 				},
 				"resource_version": schema.StringAttribute{
-					MarkdownDescription: fmt.Sprintf("An opaque value that represents the internal version of this %s that can be used by clients to determine when %s has changed. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency", objectName, objectName),
+					MarkdownDescription: fmt.Sprintf("An opaque value that represents the internal version of this %s that can be used by clients to determine when the %s has changed. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency", objectName, objectName),
 					Computed:            true,
 				},
 				"uid": schema.StringAttribute{
-					MarkdownDescription: fmt.Sprintf("The unique in time and space value for this %s. More info: http://kubernetes.io/docs/user-guide/identifiers#uids", objectName),
+					MarkdownDescription: fmt.Sprintf("The unique in time and space value for this %s. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids", objectName),
 					Computed:            true,
 				},
 			},

--- a/internal/provider/model_project.go
+++ b/internal/provider/model_project.go
@@ -87,7 +87,7 @@ type syncWindowModel struct {
 
 func projectSchemaBlocks() map[string]schema.Block {
 	return map[string]schema.Block{
-		"metadata": objectMetaSchemaListBlock("appproject", false),
+		"metadata": objectMetaSchemaListBlock("appproject"),
 		"spec": schema.ListNestedBlock{
 			Description: "ArgoCD AppProject spec.",
 			Validators: []validator.List{
@@ -390,6 +390,12 @@ func newProject(project *v1alpha1.AppProject) *projectModel {
 func newProjectSpec(spec *v1alpha1.AppProjectSpec) projectSpecModel {
 	ps := projectSpecModel{
 		Description: types.StringValue(spec.Description),
+	}
+
+	if spec.Description != "" {
+		ps.Description = types.StringValue(spec.Description)
+	} else {
+		ps.Description = types.StringNull()
 	}
 
 	// Convert source repos


### PR DESCRIPTION
**What type of PR is this?**

[//]: # (Uncomment only one <!-- /kind ... --> line, and delete the rest.)
[//]: # (For example, <!-- /kind bug --> would simply become: /kind bug  )

/kind bug
<!-- /kind chore -->
<!-- /kind cleanup -->
<!-- /kind failing-test -->
<!-- /kind enhancement -->
<!-- /kind documentation -->
<!-- /kind code-refactoring -->


**What does this PR do / why we need it**:

If `namespace` is not set the API will return `argocd` as the namespace, since that's the default. To account for this we need to set the namespace field as computed, which is also what the previous implementation had.

We need to do something similar for `description`, where if we do not set it in TF, we should not set a `description` value.

Also took the opportunity to fix some incorrect docs, which if needed can be punted for another PR.


**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [x] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #783.

**How to test changes / Special notes to the reviewer**: