### PR TITLE
fix: allow empty lists in project fields

### DIFF
--- a/internal/provider/model_project.go
+++ b/internal/provider/model_project.go
@@ -550,7 +550,7 @@ func newProjectSpec(spec *v1alpha1.AppProjectSpec) projectSpecModel {
 			}
 
 			// Handle groups
-			if len(role.Groups) > 0 {
+			if role.Groups != nil {
 				pr.Groups = make([]types.String, len(role.Groups))
 				for j, group := range role.Groups {
 					pr.Groups[j] = types.StringValue(group)
@@ -582,21 +582,21 @@ func newProjectSpec(spec *v1alpha1.AppProjectSpec) projectSpecModel {
 				swm.Timezone = types.StringValue(sw.TimeZone)
 			}
 
-			if len(sw.Applications) > 0 {
+			if sw.Applications != nil {
 				swm.Applications = make([]types.String, len(sw.Applications))
 				for j, app := range sw.Applications {
 					swm.Applications[j] = types.StringValue(app)
 				}
 			}
 
-			if len(sw.Clusters) > 0 {
+			if sw.Clusters != nil {
 				swm.Clusters = make([]types.String, len(sw.Clusters))
 				for j, cluster := range sw.Clusters {
 					swm.Clusters[j] = types.StringValue(cluster)
 				}
 			}
 
-			if len(sw.Namespaces) > 0 {
+			if sw.Namespaces != nil {
 				swm.Namespaces = make([]types.String, len(sw.Namespaces))
 				for j, ns := range sw.Namespaces {
 					swm.Namespaces[j] = types.StringValue(ns)

--- a/internal/provider/resource_project.go
+++ b/internal/provider/resource_project.go
@@ -101,13 +101,15 @@ func (r *projectResource) Create(ctx context.Context, req resource.CreateRequest
 
 	projectName := objectMeta.Name
 
+	model := data.Spec[0]
+
 	// Check feature support
-	if !r.si.IsFeatureSupported(features.ProjectSourceNamespaces) && len(data.Spec[0].SourceNamespaces) > 0 {
+	if !r.si.IsFeatureSupported(features.ProjectSourceNamespaces) && len(model.SourceNamespaces) > 0 {
 		resp.Diagnostics.Append(diagnostics.FeatureNotSupported(features.ProjectSourceNamespaces)...)
 		return
 	}
 
-	if !r.si.IsFeatureSupported(features.ProjectDestinationServiceAccounts) && len(data.Spec[0].DestinationServiceAccount) > 0 {
+	if !r.si.IsFeatureSupported(features.ProjectDestinationServiceAccounts) && len(model.DestinationServiceAccount) > 0 {
 		resp.Diagnostics.Append(diagnostics.FeatureNotSupported(features.ProjectDestinationServiceAccounts)...)
 		return
 	}
@@ -163,18 +165,66 @@ func (r *projectResource) Create(ctx context.Context, req resource.CreateRequest
 	projectData.ID = types.StringValue(projectName)
 
 	// Preserve empty lists from plan that ArgoCD might have normalized to null (issue #788)
-	// This ensures source_repos = [] stays as [] and doesn't become null
-	if data.Spec[0].SourceRepos != nil && len(data.Spec[0].SourceRepos) == 0 && projectData.Spec[0].SourceRepos == nil {
-		projectData.Spec[0].SourceRepos = make([]types.String, 0)
-	}
-	if data.Spec[0].SignatureKeys != nil && len(data.Spec[0].SignatureKeys) == 0 && projectData.Spec[0].SignatureKeys == nil {
-		projectData.Spec[0].SignatureKeys = make([]types.String, 0)
-	}
-	if data.Spec[0].SourceNamespaces != nil && len(data.Spec[0].SourceNamespaces) == 0 && projectData.Spec[0].SourceNamespaces == nil {
-		projectData.Spec[0].SourceNamespaces = make([]types.String, 0)
-	}
+	preserveEmptyLists(&data.Spec[0], &projectData.Spec[0])
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, projectData)...)
+}
+
+// preserveEmptyLists applies preservation logic to ensure empty lists and null values from the source
+// are not lost when the ArgoCD API normalizes them.
+func preserveEmptyLists(sourceModel, apiModel *projectSpecModel) {
+	// Preserve top-level empty lists
+	if sourceModel.SourceRepos != nil && len(sourceModel.SourceRepos) == 0 && apiModel.SourceRepos == nil {
+		apiModel.SourceRepos = make([]types.String, 0)
+	}
+	if sourceModel.SignatureKeys != nil && len(sourceModel.SignatureKeys) == 0 && apiModel.SignatureKeys == nil {
+		apiModel.SignatureKeys = make([]types.String, 0)
+	}
+	if sourceModel.SourceNamespaces != nil && len(sourceModel.SourceNamespaces) == 0 && apiModel.SourceNamespaces == nil {
+		apiModel.SourceNamespaces = make([]types.String, 0)
+	}
+
+	// Preserve empty groups lists in roles
+	for i := range apiModel.Role {
+		apiRole := &apiModel.Role[i]
+		for j := range sourceModel.Role {
+			sourceRole := &sourceModel.Role[j]
+			if apiRole.Name.Equal(sourceRole.Name) {
+				if sourceRole.Groups != nil && len(sourceRole.Groups) == 0 && apiRole.Groups == nil {
+					apiRole.Groups = make([]types.String, 0)
+				}
+				break
+			}
+		}
+	}
+
+	// Preserve empty lists and null values in sync windows (match by identifying fields since sync_window is a Set)
+	for i := range apiModel.SyncWindow {
+		apiSync := &apiModel.SyncWindow[i]
+		for j := range sourceModel.SyncWindow {
+			sourceSync := &sourceModel.SyncWindow[j]
+			// Match sync windows by their identifying fields
+			if apiSync.Kind.Equal(sourceSync.Kind) &&
+				apiSync.Schedule.Equal(sourceSync.Schedule) &&
+				apiSync.Duration.Equal(sourceSync.Duration) {
+				if sourceSync.Applications != nil && len(sourceSync.Applications) == 0 && apiSync.Applications == nil {
+					apiSync.Applications = make([]types.String, 0)
+				}
+				if sourceSync.Clusters != nil && len(sourceSync.Clusters) == 0 && apiSync.Clusters == nil {
+					apiSync.Clusters = make([]types.String, 0)
+				}
+				if sourceSync.Namespaces != nil && len(sourceSync.Namespaces) == 0 && apiSync.Namespaces == nil {
+					apiSync.Namespaces = make([]types.String, 0)
+				}
+				// Preserve null for manual_sync if it wasn't specified in source (issue #788)
+				// API returns false (zero value) but source has null when not specified
+				if sourceSync.ManualSync.IsNull() && apiSync.ManualSync.Equal(types.BoolValue(false)) {
+					apiSync.ManualSync = types.BoolNull()
+				}
+				break
+			}
+		}
+	}
 }
 
 func (r *projectResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
@@ -195,10 +245,10 @@ func (r *projectResource) Read(ctx context.Context, req resource.ReadRequest, re
 	projectMutex.RLock()
 	defer projectMutex.RUnlock()
 
-	r.readUnsafe(ctx, data, projectName, resp)
+	r.readUnsafe(ctx, data, nil, projectName, resp)
 }
 
-func (r *projectResource) readUnsafe(ctx context.Context, data projectModel, projectName string, resp *resource.ReadResponse) {
+func (r *projectResource) readUnsafe(ctx context.Context, data projectModel, plan *projectModel, projectName string, resp *resource.ReadResponse) {
 	// Initialize API clients
 	resp.Diagnostics.Append(r.si.InitClients(ctx)...)
 
@@ -233,24 +283,20 @@ func (r *projectResource) readUnsafe(ctx context.Context, data projectModel, pro
 	}
 
 	// Save updated data into Terraform state
-	projectData := newProject(p)
-	projectData.ID = types.StringValue(projectName)
+	apiData := newProject(p)
+	apiData.ID = types.StringValue(projectName)
 
-	// Preserve empty lists from prior state that ArgoCD might have normalized to null (issue #788)
-	// This ensures source_repos = [] in state stays as [] during reads and doesn't flip to null
+	// Preserve empty lists from prior state/plan that ArgoCD might have normalized to null (issue #788)
+	// Use plan if provided (during Update), otherwise use prior state (during Read)
 	if len(data.Spec) > 0 {
-		if data.Spec[0].SourceRepos != nil && len(data.Spec[0].SourceRepos) == 0 && projectData.Spec[0].SourceRepos == nil {
-			projectData.Spec[0].SourceRepos = make([]types.String, 0)
+		sourceModel := &data.Spec[0]
+		if plan != nil && len(plan.Spec) > 0 {
+			sourceModel = &plan.Spec[0]
 		}
-		if data.Spec[0].SignatureKeys != nil && len(data.Spec[0].SignatureKeys) == 0 && projectData.Spec[0].SignatureKeys == nil {
-			projectData.Spec[0].SignatureKeys = make([]types.String, 0)
-		}
-		if data.Spec[0].SourceNamespaces != nil && len(data.Spec[0].SourceNamespaces) == 0 && projectData.Spec[0].SourceNamespaces == nil {
-			projectData.Spec[0].SourceNamespaces = make([]types.String, 0)
-		}
+		preserveEmptyLists(sourceModel, &apiData.Spec[0])
 	}
 
-	resp.Diagnostics.Append(resp.State.Set(ctx, projectData)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, apiData)...)
 }
 
 func (r *projectResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
@@ -355,7 +401,7 @@ func (r *projectResource) Update(ctx context.Context, req resource.UpdateRequest
 
 	tflog.Trace(ctx, fmt.Sprintf("updated project %s", projectName))
 
-	// Read updated resource
+	// Read updated resource with plan context for proper empty list preservation
 	readReq := resource.ReadRequest{State: req.State}
 	readResp := resource.ReadResponse{State: resp.State, Diagnostics: resp.Diagnostics}
 
@@ -364,26 +410,8 @@ func (r *projectResource) Update(ctx context.Context, req resource.UpdateRequest
 	// Read Terraform state data into the model
 	resp.Diagnostics.Append(readReq.State.Get(ctx, &updatedData)...)
 
-	r.readUnsafe(ctx, updatedData, projectName, &readResp)
-
-	// Preserve empty lists from plan that ArgoCD might have normalized to null (issue #788)
-	// This ensures source_repos = [] stays as [] and doesn't become null after update
-	if !readResp.Diagnostics.HasError() {
-		var stateData projectModel
-		readResp.Diagnostics.Append(readResp.State.Get(ctx, &stateData)...)
-		if !readResp.Diagnostics.HasError() {
-			if data.Spec[0].SourceRepos != nil && len(data.Spec[0].SourceRepos) == 0 && stateData.Spec[0].SourceRepos == nil {
-				stateData.Spec[0].SourceRepos = make([]types.String, 0)
-			}
-			if data.Spec[0].SignatureKeys != nil && len(data.Spec[0].SignatureKeys) == 0 && stateData.Spec[0].SignatureKeys == nil {
-				stateData.Spec[0].SignatureKeys = make([]types.String, 0)
-			}
-			if data.Spec[0].SourceNamespaces != nil && len(data.Spec[0].SourceNamespaces) == 0 && stateData.Spec[0].SourceNamespaces == nil {
-				stateData.Spec[0].SourceNamespaces = make([]types.String, 0)
-			}
-			readResp.Diagnostics.Append(readResp.State.Set(ctx, stateData)...)
-		}
-	}
+	// Pass plan to readUnsafe so it uses the plan (not old state) for preservation
+	r.readUnsafe(ctx, updatedData, &data, projectName, &readResp)
 
 	resp.State = readResp.State
 	resp.Diagnostics = readResp.Diagnostics
@@ -653,16 +681,27 @@ func expandProject(ctx context.Context, data *projectModel) (metav1.ObjectMeta, 
 			window.TimeZone = sw.Timezone.ValueString()
 		}
 
-		for _, app := range sw.Applications {
-			window.Applications = append(window.Applications, app.ValueString())
+		// Initialize to empty slice if set (even if empty) to maintain empty list vs null distinction
+		// This fixes issue #788 where empty lists were incorrectly converted to null
+		if sw.Applications != nil {
+			window.Applications = make([]string, 0, len(sw.Applications))
+			for _, app := range sw.Applications {
+				window.Applications = append(window.Applications, app.ValueString())
+			}
 		}
 
-		for _, cluster := range sw.Clusters {
-			window.Clusters = append(window.Clusters, cluster.ValueString())
+		if sw.Clusters != nil {
+			window.Clusters = make([]string, 0, len(sw.Clusters))
+			for _, cluster := range sw.Clusters {
+				window.Clusters = append(window.Clusters, cluster.ValueString())
+			}
 		}
 
-		for _, ns := range sw.Namespaces {
-			window.Namespaces = append(window.Namespaces, ns.ValueString())
+		if sw.Namespaces != nil {
+			window.Namespaces = make([]string, 0, len(sw.Namespaces))
+			for _, ns := range sw.Namespaces {
+				window.Namespaces = append(window.Namespaces, ns.ValueString())
+			}
 		}
 
 		spec.SyncWindows = append(spec.SyncWindows, &window)
@@ -688,8 +727,13 @@ func expandProjectRoles(_ context.Context, roles []projectRoleModel) []v1alpha1.
 			pr.Policies = append(pr.Policies, policy.ValueString())
 		}
 
-		for _, group := range role.Groups {
-			pr.Groups = append(pr.Groups, group.ValueString())
+		// Groups is optional - initialize to empty slice if set to maintain empty list vs null distinction
+		// This fixes issue #788 where empty lists were incorrectly converted to null
+		if role.Groups != nil {
+			pr.Groups = make([]string, 0, len(role.Groups))
+			for _, group := range role.Groups {
+				pr.Groups = append(pr.Groups, group.ValueString())
+			}
 		}
 
 		result = append(result, pr)

--- a/internal/provider/resource_project_test.go
+++ b/internal/provider/resource_project_test.go
@@ -1601,3 +1601,136 @@ resource "argocd_project" "empty_repos" {
 }
 	`, name)
 }
+
+// TestAccArgoCDProject_EmptyRoleGroups tests that empty groups list in roles
+// doesn't cause "Provider produced inconsistent result after apply" error.
+func TestAccArgoCDProject_EmptyRoleGroups(t *testing.T) {
+	name := acctest.RandomWithPrefix("test-acc-empty-groups")
+	config := testAccArgoCDProjectWithEmptyRoleGroups(name)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("argocd_project.empty_groups", "metadata.0.name", name),
+					resource.TestCheckResourceAttr("argocd_project.empty_groups", "spec.0.role.0.groups.#", "0"),
+				),
+			},
+			{
+				// Apply the same configuration again to verify no drift
+				Config: config,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+func testAccArgoCDProjectWithEmptyRoleGroups(name string) string {
+	return fmt.Sprintf(`
+resource "argocd_project" "empty_groups" {
+  metadata {
+    name      = "%s"
+    namespace = "argocd"
+  }
+
+  spec {
+    description  = "project with role having empty groups"
+    source_repos = ["*"]
+
+    destination {
+      server    = "https://kubernetes.default.svc"
+      namespace = "default"
+    }
+
+    role {
+      name     = "test-role"
+      groups   = []
+      policies = ["p, proj:%s:test-role, applications, get, %s/*, allow"]
+    }
+  }
+}
+	`, name, name, name)
+}
+
+// TestAccArgoCDProject_EmptyListsComprehensive tests multiple empty list fields
+// in a single project to ensure they all work correctly together (issue #788)
+func TestAccArgoCDProject_EmptyListsComprehensive(t *testing.T) {
+	name := acctest.RandomWithPrefix("test-acc-comprehensive")
+	config := testAccArgoCDProjectWithMultipleEmptyLists(name)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("argocd_project.comprehensive", "metadata.0.name", name),
+					// Verify empty source_repos
+					resource.TestCheckResourceAttr("argocd_project.comprehensive", "spec.0.source_repos.#", "0"),
+					// Verify empty signature_keys
+					resource.TestCheckResourceAttr("argocd_project.comprehensive", "spec.0.signature_keys.#", "0"),
+					// Verify empty groups in role
+					resource.TestCheckResourceAttr("argocd_project.comprehensive", "spec.0.role.0.groups.#", "0"),
+					// Verify sync window with mixed empty/non-empty lists
+					resource.TestCheckResourceAttr("argocd_project.comprehensive", "spec.0.sync_window.0.applications.#", "1"),
+					resource.TestCheckResourceAttr("argocd_project.comprehensive", "spec.0.sync_window.0.clusters.#", "0"),
+					resource.TestCheckResourceAttr("argocd_project.comprehensive", "spec.0.sync_window.0.namespaces.#", "0"),
+				),
+			},
+			{
+				// Apply the same configuration again to verify no drift
+				Config: config,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+func testAccArgoCDProjectWithMultipleEmptyLists(name string) string {
+	return fmt.Sprintf(`
+resource "argocd_project" "comprehensive" {
+  metadata {
+    name      = "%s"
+    namespace = "argocd"
+  }
+
+  spec {
+    description     = "project testing multiple empty list fields"
+    source_repos    = []
+    signature_keys  = []
+
+    destination {
+      server    = "https://kubernetes.default.svc"
+      namespace = "default"
+    }
+
+    role {
+      name     = "test-role"
+      groups   = []
+      policies = ["p, proj:%s:test-role, applications, get, %s/*, allow"]
+    }
+
+    sync_window {
+      kind         = "allow"
+      schedule     = "0 0 * * *"
+      duration     = "1h"
+      applications = ["test-app"]
+      clusters     = []
+      namespaces   = []
+    }
+  }
+}
+	`, name, name, name)
+}


### PR DESCRIPTION
**What type of PR is this?**

[//]: # (Uncomment only one <!-- /kind ... --> line, and delete the rest.)
[//]: # (For example, <!-- /kind bug --> would simply become: /kind bug  )

/kind bug
<!-- /kind chore -->
<!-- /kind cleanup -->
<!-- /kind failing-test -->
<!-- /kind enhancement -->
<!-- /kind documentation -->
<!-- /kind code-refactoring -->

**What does this PR do / why we need it**:

If a field (e.g `source_repos`) is set to an empty list (as opposed to not being set at all in the plan), the API might not return the fields in the API response, leading to an inconsistent plan error.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #788.

**How to test changes / Special notes to the reviewer**: