### PR TITLE
fix: correct expires_in description to use valid example

### DIFF
--- a/argocd/resource_argocd_account_token.go
+++ b/argocd/resource_argocd_account_token.go
@@ -102,7 +102,7 @@ func resourceArgoCDAccountToken() *schema.Resource {
 			},
 			"expires_in": {
 				Type:         schema.TypeString,
-				Description:  "Duration before the token will expire. Valid time units are `ns`, `us` (or `µs`), `ms`, `s`, `m`, `h`. E.g. `12h`, `7d`. Default: No expiration.",
+				Description:  "Duration before the token will expire. Valid time units are `ns`, `us` (or `µs`), `ms`, `s`, `m`, `h`. E.g. `30m`, `12h`. Default: No expiration.",
 				Optional:     true,
 				ForceNew:     true,
 				ValidateFunc: validateDuration,

--- a/docs/resources/account_token.md
+++ b/docs/resources/account_token.md
@@ -35,7 +35,7 @@ resource "argocd_account_token" "foo" {
 ### Optional
 
 - `account` (String) Account name. Defaults to the current account. I.e. the account configured on the `provider` block.
-- `expires_in` (String) Duration before the token will expire. Valid time units are `ns`, `us` (or `µs`), `ms`, `s`, `m`, `h`. E.g. `12h`, `7d`. Default: No expiration.
+- `expires_in` (String) Duration before the token will expire. Valid time units are `ns`, `us` (or `µs`), `ms`, `s`, `m`, `h`. E.g. `30m`, `12h`. Default: No expiration.
 - `renew_after` (String) Duration to control token silent regeneration based on token age. Valid time units are `ns`, `us` (or `µs`), `ms`, `s`, `m`, `h`. If set, then the token will be regenerated if it is older than `renew_after`. I.e. if `currentDate - issued_at > renew_after`.
 - `renew_before` (String) Duration to control token silent regeneration based on remaining token lifetime. If `expires_in` is set, Terraform will regenerate the token if `expires_at - currentDate < renew_before`. Valid time units are `ns`, `us` (or `µs`), `ms`, `s`, `m`, `h`.
 

--- a/docs/resources/project_token.md
+++ b/docs/resources/project_token.md
@@ -36,7 +36,7 @@ resource "argocd_project_token" "secret" {
 ### Optional
 
 - `description` (String) Description of the token.
-- `expires_in` (String) Duration before the token will expire. Valid time units are `ns`, `us` (or `µs`), `ms`, `s`, `m`, `h`. E.g. `12h`, `7d`. Default: No expiration.
+- `expires_in` (String) Duration before the token will expire. Valid time units are `ns`, `us` (or `µs`), `ms`, `s`, `m`, `h`. E.g. `30m`, `12h`. Default: No expiration.
 - `renew_after` (String) Duration to control token silent regeneration based on token age. Valid time units are `ns`, `us` (or `µs`), `ms`, `s`, `m`, `h`. If set, then the token will be regenerated if it is older than `renew_after`. I.e. if `currentDate - issued_at > renew_after`.
 - `renew_before` (String) Duration to control token silent regeneration based on remaining token lifetime. If `expires_in` is set, Terraform will regenerate the token if `expires_at - currentDate < renew_before`. Valid time units are `ns`, `us` (or `µs`), `ms`, `s`, `m`, `h`.
 

--- a/internal/provider/model_project_token.go
+++ b/internal/provider/model_project_token.go
@@ -46,7 +46,7 @@ func projectTokenSchemaAttributes() map[string]schema.Attribute {
 			},
 		},
 		"expires_in": schema.StringAttribute{
-			Description: "Duration before the token will expire. Valid time units are `ns`, `us` (or `µs`), `ms`, `s`, `m`, `h`. E.g. `12h`, `7d`. Default: No expiration.",
+			Description: "Duration before the token will expire. Valid time units are `ns`, `us` (or `µs`), `ms`, `s`, `m`, `h`. E.g. `30m`, `12h`. Default: No expiration.",
 			Optional:    true,
 			PlanModifiers: []planmodifier.String{
 				stringplanmodifier.RequiresReplace(),


### PR DESCRIPTION
**What type of PR is this?**

/kind chore

**What does this PR do / why we need it**:

It just corrects an unit example in the expires_in description of the following two resources:

- argocd_account_token
- argocd_project_token

The function [time.ParseDuration](https://pkg.go.dev/time#ParseDuration) does not accept `d` days as a valid unit instead of `ns`, `us` / `µs`, `ms`, `s`, `m`, `h`. 

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [x] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #-

**How to test changes / Special notes to the reviewer**:

Nothing.