### PR TITLE
fix: metadata field updates

### DIFF
--- a/internal/provider/model_metadata.go
+++ b/internal/provider/model_metadata.go
@@ -72,14 +72,23 @@ func objectMetaSchemaAttribute(objectName string, computed bool) schema.Attribut
 			"generation": schema.Int64Attribute{
 				MarkdownDescription: "A sequence number representing a specific generation of the desired state.",
 				Computed:            true,
+				PlanModifiers: []planmodifier.Int64{
+					UseUnknownOnUpdateInt64(),
+				},
 			},
 			"resource_version": schema.StringAttribute{
 				MarkdownDescription: fmt.Sprintf("An opaque value that represents the internal version of this %s that can be used by clients to determine when the %s has changed. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency", objectName, objectName),
 				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					UseUnknownOnUpdateString(),
+				},
 			},
 			"uid": schema.StringAttribute{
 				MarkdownDescription: fmt.Sprintf("The unique in time and space value for this %s. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids", objectName),
 				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 		},
 	}
@@ -135,14 +144,23 @@ func objectMetaSchemaListBlock(objectName string) schema.Block {
 				"generation": schema.Int64Attribute{
 					MarkdownDescription: "A sequence number representing a specific generation of the desired state.",
 					Computed:            true,
+					PlanModifiers: []planmodifier.Int64{
+						UseUnknownOnUpdateInt64(),
+					},
 				},
 				"resource_version": schema.StringAttribute{
 					MarkdownDescription: fmt.Sprintf("An opaque value that represents the internal version of this %s that can be used by clients to determine when the %s has changed. Read more: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency", objectName, objectName),
 					Computed:            true,
+					PlanModifiers: []planmodifier.String{
+						UseUnknownOnUpdateString(),
+					},
 				},
 				"uid": schema.StringAttribute{
 					MarkdownDescription: fmt.Sprintf("The unique in time and space value for this %s. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids", objectName),
 					Computed:            true,
+					PlanModifiers: []planmodifier.String{
+						stringplanmodifier.UseStateForUnknown(),
+					},
 				},
 			},
 		},

--- a/internal/provider/planmodifiers.go
+++ b/internal/provider/planmodifiers.go
@@ -1,0 +1,92 @@
+package provider
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// UseUnknownOnUpdate returns a plan modifier that sets the value to unknown
+// whenever the resource is being updated. This is useful for computed fields like
+// resource_version and generation that change on every Kubernetes API call.
+//
+// Unlike UseStateForUnknown which preserves the prior state value, this modifier
+// marks the value as unknown during updates so that Terraform accepts any value
+// returned by the provider after apply.
+//
+// Fixes: https://github.com/argoproj-labs/terraform-provider-argocd/issues/807
+func UseUnknownOnUpdateString() planmodifier.String {
+	return useUnknownOnUpdateStringModifier{}
+}
+
+type useUnknownOnUpdateStringModifier struct{}
+
+func (m useUnknownOnUpdateStringModifier) Description(_ context.Context) string {
+	return "Sets the value to unknown during updates since server-managed fields change on every API call."
+}
+
+func (m useUnknownOnUpdateStringModifier) MarkdownDescription(_ context.Context) string {
+	return "Sets the value to unknown during updates since server-managed fields change on every API call."
+}
+
+func (m useUnknownOnUpdateStringModifier) PlanModifyString(_ context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
+	// If there's no state (create), leave as unknown (default behavior)
+	if req.State.Raw.IsNull() {
+		return
+	}
+
+	// If the plan is being destroyed, no need to modify
+	if req.Plan.Raw.IsNull() {
+		return
+	}
+
+	// This is an update - check if any values in the resource are changing
+	// by comparing the full plan to the full state using Equal
+	if !req.Plan.Raw.Equal(req.State.Raw) {
+		// Resource is being modified, mark as unknown so any value is accepted
+		resp.PlanValue = types.StringUnknown()
+		return
+	}
+
+	// No change to the resource, preserve the state value
+	resp.PlanValue = req.StateValue
+}
+
+// UseUnknownOnUpdateInt64 returns a plan modifier for Int64 attributes
+// that sets the value to unknown whenever the resource is being updated.
+func UseUnknownOnUpdateInt64() planmodifier.Int64 {
+	return useUnknownOnUpdateInt64Modifier{}
+}
+
+type useUnknownOnUpdateInt64Modifier struct{}
+
+func (m useUnknownOnUpdateInt64Modifier) Description(_ context.Context) string {
+	return "Sets the value to unknown during updates since server-managed fields change on every API call."
+}
+
+func (m useUnknownOnUpdateInt64Modifier) MarkdownDescription(_ context.Context) string {
+	return "Sets the value to unknown during updates since server-managed fields change on every API call."
+}
+
+func (m useUnknownOnUpdateInt64Modifier) PlanModifyInt64(_ context.Context, req planmodifier.Int64Request, resp *planmodifier.Int64Response) {
+	// If there's no state (create), leave as unknown (default behavior)
+	if req.State.Raw.IsNull() {
+		return
+	}
+
+	// If the plan is being destroyed, no need to modify
+	if req.Plan.Raw.IsNull() {
+		return
+	}
+
+	// This is an update - check if any values in the resource are changing
+	if !req.Plan.Raw.Equal(req.State.Raw) {
+		// Resource is being modified, mark as unknown so any value is accepted
+		resp.PlanValue = types.Int64Unknown()
+		return
+	}
+
+	// No change to the resource, preserve the state value
+	resp.PlanValue = req.StateValue
+}


### PR DESCRIPTION
**What type of PR is this?**

[//]: # (Uncomment only one <!-- /kind ... --> line, and delete the rest.)
[//]: # (For example, <!-- /kind bug --> would simply become: /kind bug  )

/kind bug
<!-- /kind chore -->
<!-- /kind cleanup -->
<!-- /kind failing-test -->
<!-- /kind enhancement -->
<!-- /kind documentation -->
<!-- /kind code-refactoring -->

**What does this PR do / why we need it**:

Using lifecycle `{ ignore_changes = [metadata] }` with metadata fields caused "Provider produced inconsistent result after apply" errors because `resource_version` and `generation` are server-managed fields that change on every API call.

For ignored attributes, Terraform preserves the planned values instead of reading them from the API, which becomes problematic when it then reads back the values from the API after preserving said values.

Because of that we need to add custom plan modifiers (`UseUnknownOnUpdateString` and `UseUnknownOnUpdateInt64`) that mark these computed fields as `unknown` during updates, so Terraform accepts any value returned by the provider.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #807.

**How to test changes / Special notes to the reviewer**: