### PR TITLE
feat(argocd_applicationset): add `requeue_after_seconds` field to Git Generator

### DIFF
--- a/argocd/resource_argocd_application_set_test.go
+++ b/argocd/resource_argocd_application_set_test.go
@@ -1265,6 +1265,7 @@ resource "argocd_application_set" "git_directories" {
 					path = "applicationset/examples/git-generator-directory/excludes/cluster-addons/exclude-helm-guestbook"
 					exclude = true
 				}
+				requeue_after_seconds = "30"
 			}
 		}
 
@@ -1441,6 +1442,7 @@ resource "argocd_application_set" "matrix" {
 						directory {
 							path = "applicationset/examples/matrix/cluster-addons/*"
 						}
+						requeue_after_seconds = "30"
 					}
 				}
 
@@ -1493,13 +1495,13 @@ resource "argocd_application_set" "matrix-plugin_generator" {
 				generator {
 					plugin {
 						config_map_ref = "plugin"
-		
+
 						input {
 							parameters = {
 								key1 = "value1"
 							}
 						}
-		
+
 						requeue_after_seconds = 30
 					}
 				}

--- a/argocd/schema_application_set.go
+++ b/argocd/schema_application_set.go
@@ -414,6 +414,11 @@ func applicationSetGitGeneratorSchemaV0() *schema.Schema {
 					Description: "Prefix for all path-related parameter names.",
 					Optional:    true,
 				},
+				"requeue_after_seconds": {
+					Type:        schema.TypeString,
+					Description: "How often to check for changes (in seconds). Default: 3min.",
+					Optional:    true,
+				},
 				"template": {
 					Type:        schema.TypeList,
 					Description: "Generator template. Used to override the values of the spec-level template.",

--- a/argocd/structure_application_set.go
+++ b/argocd/structure_application_set.go
@@ -220,6 +220,15 @@ func expandApplicationSetGitGenerator(gg interface{}, featureMultipleApplication
 		}
 	}
 
+	if v, ok := g["requeue_after_seconds"].(string); ok && len(v) > 0 {
+		ras, err := convertStringToInt64Pointer(v)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert requeue_after_seconds to *int64: %w", err)
+		}
+
+		asg.Git.RequeueAfterSeconds = ras
+	}
+
 	if v, ok := g["template"].([]interface{}); ok && len(v) > 0 {
 		temp, err := expandApplicationSetTemplate(v[0], featureMultipleApplicationSourcesSupported, featureApplicationSourceNameSupported)
 		if err != nil {
@@ -1163,6 +1172,10 @@ func flattenApplicationSetGitGenerator(gg *application.GitGenerator) []map[strin
 		}
 
 		g["file"] = files
+	}
+
+	if gg.RequeueAfterSeconds != nil {
+		g["requeue_after_seconds"] = convertInt64PointerToString(gg.RequeueAfterSeconds)
 	}
 
 	return []map[string]interface{}{g}

--- a/docs/resources/application_set.md
+++ b/docs/resources/application_set.md
@@ -1239,6 +1239,7 @@ Optional:
 - `directory` (Block List) List of directories in the source repository to use when template the Application.. (see [below for nested schema](#nestedblock--spec--generator--git--directory))
 - `file` (Block List) List of files in the source repository to use when template the Application. (see [below for nested schema](#nestedblock--spec--generator--git--file))
 - `path_param_prefix` (String) Prefix for all path-related parameter names.
+- `requeue_after_seconds` (String) How often to check for changes (in seconds). Default: 3min.
 - `revision` (String) Revision of the source repository to use.
 - `template` (Block List, Max: 1) Generator template. Used to override the values of the spec-level template. (see [below for nested schema](#nestedblock--spec--generator--git--template))
 - `values` (Map of String) Arbitrary string key-value pairs to pass to the template via the values field of the git generator.
@@ -2464,6 +2465,7 @@ Optional:
 - `directory` (Block List) List of directories in the source repository to use when template the Application.. (see [below for nested schema](#nestedblock--spec--generator--matrix--generator--git--directory))
 - `file` (Block List) List of files in the source repository to use when template the Application. (see [below for nested schema](#nestedblock--spec--generator--matrix--generator--git--file))
 - `path_param_prefix` (String) Prefix for all path-related parameter names.
+- `requeue_after_seconds` (String) How often to check for changes (in seconds). Default: 3min.
 - `revision` (String) Revision of the source repository to use.
 - `template` (Block List, Max: 1) Generator template. Used to override the values of the spec-level template. (see [below for nested schema](#nestedblock--spec--generator--matrix--generator--git--template))
 - `values` (Map of String) Arbitrary string key-value pairs to pass to the template via the values field of the git generator.
@@ -3687,6 +3689,7 @@ Optional:
 - `directory` (Block List) List of directories in the source repository to use when template the Application.. (see [below for nested schema](#nestedblock--spec--generator--matrix--generator--matrix--generator--git--directory))
 - `file` (Block List) List of files in the source repository to use when template the Application. (see [below for nested schema](#nestedblock--spec--generator--matrix--generator--matrix--generator--git--file))
 - `path_param_prefix` (String) Prefix for all path-related parameter names.
+- `requeue_after_seconds` (String) How often to check for changes (in seconds). Default: 3min.
 - `revision` (String) Revision of the source repository to use.
 - `template` (Block List, Max: 1) Generator template. Used to override the values of the spec-level template. (see [below for nested schema](#nestedblock--spec--generator--matrix--generator--matrix--generator--git--template))
 - `values` (Map of String) Arbitrary string key-value pairs to pass to the template via the values field of the git generator.
@@ -6346,6 +6349,7 @@ Optional:
 - `directory` (Block List) List of directories in the source repository to use when template the Application.. (see [below for nested schema](#nestedblock--spec--generator--matrix--generator--merge--generator--git--directory))
 - `file` (Block List) List of files in the source repository to use when template the Application. (see [below for nested schema](#nestedblock--spec--generator--matrix--generator--merge--generator--git--file))
 - `path_param_prefix` (String) Prefix for all path-related parameter names.
+- `requeue_after_seconds` (String) How often to check for changes (in seconds). Default: 3min.
 - `revision` (String) Revision of the source repository to use.
 - `template` (Block List, Max: 1) Generator template. Used to override the values of the spec-level template. (see [below for nested schema](#nestedblock--spec--generator--matrix--generator--merge--generator--git--template))
 - `values` (Map of String) Arbitrary string key-value pairs to pass to the template via the values field of the git generator.
@@ -10442,6 +10446,7 @@ Optional:
 - `directory` (Block List) List of directories in the source repository to use when template the Application.. (see [below for nested schema](#nestedblock--spec--generator--merge--generator--git--directory))
 - `file` (Block List) List of files in the source repository to use when template the Application. (see [below for nested schema](#nestedblock--spec--generator--merge--generator--git--file))
 - `path_param_prefix` (String) Prefix for all path-related parameter names.
+- `requeue_after_seconds` (String) How often to check for changes (in seconds). Default: 3min.
 - `revision` (String) Revision of the source repository to use.
 - `template` (Block List, Max: 1) Generator template. Used to override the values of the spec-level template. (see [below for nested schema](#nestedblock--spec--generator--merge--generator--git--template))
 - `values` (Map of String) Arbitrary string key-value pairs to pass to the template via the values field of the git generator.
@@ -11665,6 +11670,7 @@ Optional:
 - `directory` (Block List) List of directories in the source repository to use when template the Application.. (see [below for nested schema](#nestedblock--spec--generator--merge--generator--matrix--generator--git--directory))
 - `file` (Block List) List of files in the source repository to use when template the Application. (see [below for nested schema](#nestedblock--spec--generator--merge--generator--matrix--generator--git--file))
 - `path_param_prefix` (String) Prefix for all path-related parameter names.
+- `requeue_after_seconds` (String) How often to check for changes (in seconds). Default: 3min.
 - `revision` (String) Revision of the source repository to use.
 - `template` (Block List, Max: 1) Generator template. Used to override the values of the spec-level template. (see [below for nested schema](#nestedblock--spec--generator--merge--generator--matrix--generator--git--template))
 - `values` (Map of String) Arbitrary string key-value pairs to pass to the template via the values field of the git generator.
@@ -14324,6 +14330,7 @@ Optional:
 - `directory` (Block List) List of directories in the source repository to use when template the Application.. (see [below for nested schema](#nestedblock--spec--generator--merge--generator--merge--generator--git--directory))
 - `file` (Block List) List of files in the source repository to use when template the Application. (see [below for nested schema](#nestedblock--spec--generator--merge--generator--merge--generator--git--file))
 - `path_param_prefix` (String) Prefix for all path-related parameter names.
+- `requeue_after_seconds` (String) How often to check for changes (in seconds). Default: 3min.
 - `revision` (String) Revision of the source repository to use.
 - `template` (Block List, Max: 1) Generator template. Used to override the values of the spec-level template. (see [below for nested schema](#nestedblock--spec--generator--merge--generator--merge--generator--git--template))
 - `values` (Map of String) Arbitrary string key-value pairs to pass to the template via the values field of the git generator.


### PR DESCRIPTION
**What type of PR is this?**

/kind enhancement

**What does this PR do / why we need it**:

- There was given a configuration variable `requeue_after_seconds` for SCM Provider Applicationset but not for Git Generators. This PR enhances the Git generator to configure `requeue_after_seconds` from terraform.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [x] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #686 

**How to test changes / Special notes to the reviewer**:
