### PR TITLE
fix(app)!: remove default value for source.path 

### DIFF
--- a/argocd/schema_application.go
+++ b/argocd/schema_application.go
@@ -428,7 +428,6 @@ func applicationSpecSchemaV1() *schema.Schema {
 								Type:     schema.TypeString,
 								Optional: true,
 								// TODO: add validator to test path is not absolute
-								Default: ".",
 							},
 							"target_revision": {
 								Type:     schema.TypeString,


### PR DESCRIPTION
**What type of PR is this?**

[//]: # (Uncomment only one <!-- /kind ... --> line, and delete the rest.)
[//]: # (For example, <!-- /kind bug --> would simply become: /kind bug  )

<!-- /kind bug -->
<!-- /kind chore -->
<!-- /kind cleanup -->
<!-- /kind failing-test -->
<!-- /kind enhancement -->
<!-- /kind documentation -->
<!-- /kind code-refactoring -->

/kind bug

**What does this PR do / why we need it**:

**Breaking** change!

Removes the `source.path` default value on the Argo CD Application resource. This aligns the resource schema with the Argo CD API that was changed a while ago.

**Have you updated the necessary documentation?**

* [x] Documentation update is required by this PR.
* [ ] Documentation has been updated.

-> requires a v8 release + special note in the release notes

**Which issue(s) this PR fixes**:

Fixes #408 

**How to test changes / Special notes to the reviewer**:

See https://github.com/argoproj-labs/terraform-provider-argocd/issues/408#issuecomment-3872378282 for the other option how we could solve this issue. I decided against it since it adds more logic/code and doesn't represent the behavior of the Argo CD API.