### PR TITLE
fix: project policies can also contain namespaces

### DIFF
--- a/argocd/utils.go
+++ b/argocd/utils.go
@@ -36,6 +36,7 @@ func convertStringToInt64Pointer(s string) (*int64, error) {
 
 	return &i, nil
 }
+
 func isKeyInMap(key string, d map[string]interface{}) bool {
 	if d == nil {
 		return false
@@ -157,9 +158,9 @@ func validatePolicy(project string, role string, policy string) error {
 	// object
 	object := strings.Trim(policyComponents[4], " ")
 
-	objectRegexp, err := regexp.Compile(fmt.Sprintf(`^%s/[*\w-.]+$`, project))
+	objectRegexp, err := regexp.Compile(fmt.Sprintf(`^%s(/[*\w-.]+){1,2}$`, project))
 	if err != nil || !objectRegexp.MatchString(object) {
-		return fmt.Errorf("invalid policy rule '%s': object must be of form '%s/*' or '%s/<APPNAME>', not '%s'", policy, project, project, object)
+		return fmt.Errorf("invalid policy rule '%s': object must be of form '%s/*' or '%s/<APPNAME>' or '%s/<NS>/<APPNAME>', not '%s'", policy, project, project, project, object)
 	}
 
 	// effect

--- a/argocd/utils_test.go
+++ b/argocd/utils_test.go
@@ -61,6 +61,17 @@ func TestValidatePolicy(t *testing.T) {
 			expectError: false,
 		},
 		{
+			name:        "Object with valid ns/app combo",
+			policy:      "p, proj:myproject:admin, applications, get, myproject/default/app-01, allow",
+			expectError: false,
+		},
+		{
+			name:        "Object with valid ns wildcard",
+			policy:      "p, proj:myproject:admin, applications, get, myproject/default/*, allow",
+			expectError: false,
+		},
+
+		{
 			name:        "Object with dash and dot in name",
 			policy:      "p, proj:myproject:admin, applications, get, myproject/app-1.2, allow",
 			expectError: false,

--- a/internal/provider/resource_project_test.go
+++ b/internal/provider/resource_project_test.go
@@ -318,6 +318,31 @@ func TestAccArgoCDProjectWithFineGrainedPolicy(t *testing.T) {
 	})
 }
 
+func TestAccArgoCDProjectWithAppsInAnyNSPolicy(t *testing.T) {
+	name := acctest.RandomWithPrefix("test-acc")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t); testAccPreCheckFeatureSupported(t, features.ProjectFineGrainedPolicy) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccArgoCDProjectWithAppsInAnyNSPolicy(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(
+						"argocd_project.app_in_any_ns_policy",
+						"metadata.0.uid",
+					),
+					resource.TestCheckResourceAttr(
+						"argocd_project.app_in_any_ns_policy",
+						"spec.0.role.0.policies.#",
+						"2",
+					),
+				),
+			},
+		},
+	})
+}
+
 func testAccArgoCDProjectSimple(name string) string {
 	return fmt.Sprintf(`
 resource "argocd_project" "simple" {
@@ -1350,6 +1375,38 @@ func testAccArgoCDProjectWithFineGrainedPolicy(name string) string {
         policies = [
           "p, proj:%[1]s:fine-grained, applications, update/*, %[1]s/*, allow",
           "p, proj:%[1]s:fine-grained, applications, delete/*/Pod/*/*, %[1]s/*, allow",
+        ]
+      }
+    }
+  }
+	`, name)
+}
+
+func testAccArgoCDProjectWithAppsInAnyNSPolicy(name string) string {
+	return fmt.Sprintf(`
+  resource "argocd_project" "app_in_any_ns_policy" {
+    metadata {
+      name      = "%[1]s"
+      namespace = "argocd"
+      labels = {
+        acceptance = "true"
+      }
+    }
+
+    spec {
+      description  = "simple project with multi-ns policy"
+      source_repos = ["*"]
+
+      destination {
+        server    = "https://kubernetes.default.svc"
+        namespace = "default"
+      }
+
+      role {
+        name = "multi-ns"
+        policies = [
+          "p, proj:%[1]s:multi-ns, applications, update/*, %[1]s/*/multi-ns, allow",
+          "p, proj:%[1]s:multi-ns, applications, delete/*/Pod/default/*, %[1]s/*, allow",
         ]
       }
     }


### PR DESCRIPTION
**What type of PR is this?**

[//]: # (Uncomment only one <!-- /kind ... --> line, and delete the rest.)
[//]: # (For example, <!-- /kind bug --> would simply become: /kind bug  )

/kind bug
<!-- /kind bug -->
<!-- /kind chore -->
<!-- /kind cleanup -->
<!-- /kind failing-test -->
<!-- /kind enhancement -->
<!-- /kind documentation -->
<!-- /kind code-refactoring -->


**What does this PR do / why we need it**:

<img width="858" height="393" alt="image" src="https://github.com/user-attachments/assets/a9dfefcc-56b8-4cc5-adb5-16062159ed6a" />

https://argo-cd.readthedocs.io/en/stable/operator-manual/rbac/#application-in-any-namespaces

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #753 

**How to test changes / Special notes to the reviewer**: