### PR TITLE
feat(argocd_applicationset): add exclude field to Git Generator for file

### DIFF
--- a/argocd/resource_argocd_application_set_test.go
+++ b/argocd/resource_argocd_application_set_test.go
@@ -151,12 +151,11 @@ func TestAccArgoCDApplicationSet_gitFiles(t *testing.T) {
 					),
 					resource.TestCheckResourceAttrSet(
 						"argocd_application_set.git_files",
-						"spec.0.generator.0.git.0.file.0.exclude",
+						"spec.0.generator.0.git.0.file.1.path",
 					),
-					resource.TestCheckResourceAttr(
+					resource.TestCheckResourceAttrSet(
 						"argocd_application_set.git_files",
-						"spec.0.generator.0.git.0.values.foo",
-						"bar",
+						"spec.0.generator.0.git.0.file.1.exclude",
 					),
 					resource.TestCheckResourceAttr(
 						"argocd_application_set.git_files",
@@ -1417,6 +1416,9 @@ resource "argocd_application_set" "git_files" {
 
 				file {
 					path = "applicationset/examples/git-generator-files-discovery/cluster-config/**/config.json"
+				}
+				file {
+					path = "applicationset/examples/git-generator-files-discovery/cluster-config/*/dev/config.json"
 					exclude = true
 				}
 				values = {

--- a/argocd/resource_argocd_application_set_test.go
+++ b/argocd/resource_argocd_application_set_test.go
@@ -123,7 +123,7 @@ func TestAccArgoCDApplicationSet_gitDirectories(t *testing.T) {
 					),
 				),
 			},
-			{
+			{rce
 				ResourceName:            "argocd_application_set.git_directories",
 				ImportState:             true,
 				ImportStateVerify:       true,

--- a/argocd/resource_argocd_application_set_test.go
+++ b/argocd/resource_argocd_application_set_test.go
@@ -123,7 +123,7 @@ func TestAccArgoCDApplicationSet_gitDirectories(t *testing.T) {
 					),
 				),
 			},
-			{rce
+			{
 				ResourceName:            "argocd_application_set.git_directories",
 				ImportState:             true,
 				ImportStateVerify:       true,

--- a/argocd/resource_argocd_application_set_test.go
+++ b/argocd/resource_argocd_application_set_test.go
@@ -149,6 +149,15 @@ func TestAccArgoCDApplicationSet_gitFiles(t *testing.T) {
 						"argocd_application_set.git_files",
 						"spec.0.generator.0.git.0.file.0.path",
 					),
+					resource.TestCheckResourceAttrSet(
+						"argocd_application_set.git_exclude",
+						"spec.0.generator.0.git.0.file.0.exclude",
+					),
+					resource.TestCheckResourceAttr(
+						"argocd_application_set.git_files",
+						"spec.0.generator.0.git.0.values.foo",
+						"bar",
+					),
 					resource.TestCheckResourceAttr(
 						"argocd_application_set.git_files",
 						"spec.0.generator.0.git.0.values.foo",
@@ -1408,6 +1417,7 @@ resource "argocd_application_set" "git_files" {
 
 				file {
 					path = "applicationset/examples/git-generator-files-discovery/cluster-config/**/config.json"
+					exclude = true
 				}
 				values = {
 					foo = "bar"

--- a/argocd/resource_argocd_application_set_test.go
+++ b/argocd/resource_argocd_application_set_test.go
@@ -150,7 +150,7 @@ func TestAccArgoCDApplicationSet_gitFiles(t *testing.T) {
 						"spec.0.generator.0.git.0.file.0.path",
 					),
 					resource.TestCheckResourceAttrSet(
-						"argocd_application_set.git_exclude",
+						"argocd_application_set.git_files",
 						"spec.0.generator.0.git.0.file.0.exclude",
 					),
 					resource.TestCheckResourceAttr(

--- a/argocd/schema_application_set.go
+++ b/argocd/schema_application_set.go
@@ -396,6 +396,12 @@ func applicationSetGitGeneratorSchemaV0() *schema.Schema {
 								Description: "Path to the file in the repository.",
 								Required:    true,
 							},
+							"exclude": {
+								Type:        schema.TypeBool,
+								Description: "Exclude file when generating parameters.",
+								Optional:    true,
+								Default:     false,
+							},
 						},
 					},
 				},

--- a/argocd/structure_application_set.go
+++ b/argocd/structure_application_set.go
@@ -1208,7 +1208,8 @@ func flattenApplicationSetGitGenerator(gg *application.GitGenerator) []map[strin
 		files := make([]map[string]interface{}, len(gg.Files))
 		for i, f := range gg.Files {
 			files[i] = map[string]interface{}{
-				"path": f.Path,
+				"path":    f.Path,
+				"exclude": f.Exclude,
 			}
 		}
 

--- a/argocd/structure_application_set.go
+++ b/argocd/structure_application_set.go
@@ -216,6 +216,10 @@ func expandApplicationSetGitGenerator(gg interface{}, featureMultipleApplication
 				Path: f["path"].(string),
 			}
 
+			if e, ok := f["exclude"].(bool); ok {
+				file.Exclude = e
+			}
+
 			asg.Git.Files = append(asg.Git.Files, file)
 		}
 	}

--- a/docs/resources/application_set.md
+++ b/docs/resources/application_set.md
@@ -144,8 +144,12 @@ resource "argocd_application_set" "git_files" {
         revision = "HEAD"
 
         file {
-          path    = "applicationset/examples/git-generator-files-discovery/cluster-config/**/config.json"
-          exclude = false
+          path = "applicationset/examples/git-generator-files-discovery/cluster-config/**/config.json"
+        }
+
+        file {
+          path    = "applicationset/examples/git-generator-files-discovery/cluster-config/*/dev/config.json"
+          exclude = true
         }
       }
     }

--- a/docs/resources/application_set.md
+++ b/docs/resources/application_set.md
@@ -144,7 +144,8 @@ resource "argocd_application_set" "git_files" {
         revision = "HEAD"
 
         file {
-          path = "applicationset/examples/git-generator-files-discovery/cluster-config/**/config.json"
+          path    = "applicationset/examples/git-generator-files-discovery/cluster-config/**/config.json"
+          exclude = false
         }
       }
     }
@@ -1360,6 +1361,10 @@ Optional:
 Required:
 
 - `path` (String) Path to the file in the repository.
+
+Optional:
+
+- `exclude` (Boolean) Exclude file when generating parameters.
 
 
 <a id="nestedblock--spec--generator--git--template"></a>
@@ -2585,6 +2590,10 @@ Required:
 
 - `path` (String) Path to the file in the repository.
 
+Optional:
+
+- `exclude` (Boolean) Exclude file when generating parameters.
+
 
 <a id="nestedblock--spec--generator--matrix--generator--git--template"></a>
 ### Nested Schema for `spec.generator.matrix.generator.git.template`
@@ -3806,6 +3815,10 @@ Optional:
 Required:
 
 - `path` (String) Path to the file in the repository.
+
+Optional:
+
+- `exclude` (Boolean) Exclude file when generating parameters.
 
 
 <a id="nestedblock--spec--generator--matrix--generator--matrix--generator--git--template"></a>
@@ -6501,6 +6514,10 @@ Optional:
 Required:
 
 - `path` (String) Path to the file in the repository.
+
+Optional:
+
+- `exclude` (Boolean) Exclude file when generating parameters.
 
 
 <a id="nestedblock--spec--generator--matrix--generator--merge--generator--git--template"></a>
@@ -10671,6 +10688,10 @@ Required:
 
 - `path` (String) Path to the file in the repository.
 
+Optional:
+
+- `exclude` (Boolean) Exclude file when generating parameters.
+
 
 <a id="nestedblock--spec--generator--merge--generator--git--template"></a>
 ### Nested Schema for `spec.generator.merge.generator.git.template`
@@ -11892,6 +11913,10 @@ Optional:
 Required:
 
 - `path` (String) Path to the file in the repository.
+
+Optional:
+
+- `exclude` (Boolean) Exclude file when generating parameters.
 
 
 <a id="nestedblock--spec--generator--merge--generator--matrix--generator--git--template"></a>
@@ -14587,6 +14612,10 @@ Optional:
 Required:
 
 - `path` (String) Path to the file in the repository.
+
+Optional:
+
+- `exclude` (Boolean) Exclude file when generating parameters.
 
 
 <a id="nestedblock--spec--generator--merge--generator--merge--generator--git--template"></a>

--- a/examples/resources/argocd_application_set/resource.tf
+++ b/examples/resources/argocd_application_set/resource.tf
@@ -130,7 +130,11 @@ resource "argocd_application_set" "git_files" {
 
         file {
           path    = "applicationset/examples/git-generator-files-discovery/cluster-config/**/config.json"
-          exclude = false
+        }
+
+        file {
+          path    = "applicationset/examples/git-generator-files-discovery/cluster-config/*/dev/config.json"
+          exclude = true
         }
       }
     }

--- a/examples/resources/argocd_application_set/resource.tf
+++ b/examples/resources/argocd_application_set/resource.tf
@@ -129,7 +129,7 @@ resource "argocd_application_set" "git_files" {
         revision = "HEAD"
 
         file {
-          path    = "applicationset/examples/git-generator-files-discovery/cluster-config/**/config.json"
+          path = "applicationset/examples/git-generator-files-discovery/cluster-config/**/config.json"
         }
 
         file {

--- a/examples/resources/argocd_application_set/resource.tf
+++ b/examples/resources/argocd_application_set/resource.tf
@@ -129,7 +129,8 @@ resource "argocd_application_set" "git_files" {
         revision = "HEAD"
 
         file {
-          path = "applicationset/examples/git-generator-files-discovery/cluster-config/**/config.json"
+          path    = "applicationset/examples/git-generator-files-discovery/cluster-config/**/config.json"
+          exclude = false
         }
       }
     }


### PR DESCRIPTION
**What type of PR is this?**

/kind enhancement

**What does this PR do / why we need it**:
There was given a configuration variable `exclude` for Git Generators of directory but not for Git Generators of file. This PR enhances the Git generator to configure `exclude` from terraform.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [x] Documentation has been updated.

**Which issue(s) this PR fixes**:
Fixes #847