### PR TITLE
fix: don't use potentially empty list for string format

### DIFF
--- a/argocd/resource_argocd_application.go
+++ b/argocd/resource_argocd_application.go
@@ -360,7 +360,7 @@ func resourceArgoCDApplicationUpdate(ctx context.Context, d *schema.ResourceData
 		if err = retry.RetryContext(ctx, d.Timeout(schema.TimeoutUpdate), func() *retry.RetryError {
 			var list *application.ApplicationList
 			if list, err = si.ApplicationClient.List(ctx, appQuery); err != nil {
-				return retry.NonRetryableError(fmt.Errorf("error while waiting for application %s to be synced and healthy: %s", list.Items[0].Name, err))
+				return retry.NonRetryableError(fmt.Errorf("error while waiting for application %s to be synced and healthy: %s", *appQuery.Name, err))
 			}
 
 			if len(list.Items) != 1 {


### PR DESCRIPTION
**What type of PR is this?**

[//]: # (Uncomment only one <!-- /kind ... --> line, and delete the rest.)
[//]: # (For example, <!-- /kind bug --> would simply become: /kind bug  )
/kind bug
<!-- /kind bug -->
<!-- /kind chore -->
<!-- /kind cleanup -->
<!-- /kind failing-test -->
<!-- /kind enhancement -->
<!-- /kind documentation -->
<!-- /kind code-refactoring -->


**What does this PR do / why we need it**:

Avoids a nil pointer crash when `ApplicationClient.List` returns an error and an empty list.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #883 

**How to test changes / Special notes to the reviewer**: