### PR TITLE
fix: prevent panic when removing roles from argocd_project on update

### DIFF
--- a/internal/provider/resource_project.go
+++ b/internal/provider/resource_project.go
@@ -389,7 +389,7 @@ func (r *projectResource) Update(ctx context.Context, req resource.UpdateRequest
 
 	// Preserve preexisting JWTs for managed roles
 	roles := expandProjectRoles(ctx, data.Spec[0].Role)
-	for _, r := range roles {
+	for specIdx, r := range roles {
 		var pr *v1alpha1.ProjectRole
 
 		var i int
@@ -406,8 +406,10 @@ func (r *projectResource) Update(ctx context.Context, req resource.UpdateRequest
 				return
 			}
 		} else {
-			// Only preserve preexisting JWTs for managed roles if we found an existing matching project
-			spec.Roles[i].JWTTokens = pr.JWTTokens
+			// Only preserve preexisting JWTs for managed roles if we found an existing matching role.
+			// Note: i indexes the existing project's roles (p), so we must write to spec.Roles using
+			// the desired-spec index (specIdx), which is aligned with the roles slice we are iterating.
+			spec.Roles[specIdx].JWTTokens = pr.JWTTokens
 		}
 	}
 

--- a/internal/provider/resource_project.go
+++ b/internal/provider/resource_project.go
@@ -387,9 +387,7 @@ func (r *projectResource) Update(ctx context.Context, req resource.UpdateRequest
 		return
 	}
 
-	// Preserve preexisting JWTs for managed roles
-	roles := expandProjectRoles(ctx, data.Spec[0].Role)
-	for specIdx, r := range roles {
+	for specIdx, r := range spec.Roles {
 		var pr *v1alpha1.ProjectRole
 
 		var i int

--- a/internal/provider/resource_project_test.go
+++ b/internal/provider/resource_project_test.go
@@ -180,6 +180,47 @@ func TestAccArgoCDProjectUpdateAddRole(t *testing.T) {
 	})
 }
 
+func TestAccArgoCDProjectRemoveLeadingRoles(t *testing.T) {
+	// Regression test: removing roles so that a retained role keeps a higher
+	// index in the existing project than its position in the new desired spec
+	// used to panic with "index out of range" while preserving JWT tokens.
+	name := acctest.RandomWithPrefix("test-acc")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccArgoCDProjectThreeRoles(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"argocd_project.three_roles",
+						"spec.0.role.#",
+						"3",
+					),
+				),
+			},
+			{
+				// Keep only the last role: in the existing project it sits at
+				// index 2, but the new spec has length 1.
+				Config: testAccArgoCDProjectThreeRolesKeepLast(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"argocd_project.three_roles",
+						"spec.0.role.#",
+						"1",
+					),
+					resource.TestCheckResourceAttr(
+						"argocd_project.three_roles",
+						"spec.0.role.0.name",
+						"role-c",
+					),
+				),
+			},
+		},
+	})
+}
+
 func TestAccArgoCDProjectWithClustersRepositoriesRolePolicy(t *testing.T) {
 	name := acctest.RandomWithPrefix("test-acc")
 
@@ -828,6 +869,72 @@ func testAccArgoCDProjectSimpleWithRole(name string) string {
     }
   }
 	`, name, name, name, name, name)
+}
+
+func testAccArgoCDProjectThreeRoles(name string) string {
+	return fmt.Sprintf(`
+  resource "argocd_project" "three_roles" {
+    metadata {
+      name      = "%[1]s"
+      namespace = "argocd"
+    }
+
+    spec {
+      description  = "three roles project"
+      source_repos = ["*"]
+
+      destination {
+        name      = "anothercluster"
+        namespace = "bar"
+      }
+      role {
+        name = "role-a"
+        policies = [
+          "p, proj:%[1]s:role-a, applications, get, %[1]s/*, allow",
+        ]
+      }
+      role {
+        name = "role-b"
+        policies = [
+          "p, proj:%[1]s:role-b, applications, get, %[1]s/*, allow",
+        ]
+      }
+      role {
+        name = "role-c"
+        policies = [
+          "p, proj:%[1]s:role-c, applications, get, %[1]s/*, allow",
+        ]
+      }
+    }
+  }
+	`, name)
+}
+
+func testAccArgoCDProjectThreeRolesKeepLast(name string) string {
+	return fmt.Sprintf(`
+  resource "argocd_project" "three_roles" {
+    metadata {
+      name      = "%[1]s"
+      namespace = "argocd"
+    }
+
+    spec {
+      description  = "three roles project"
+      source_repos = ["*"]
+
+      destination {
+        name      = "anothercluster"
+        namespace = "bar"
+      }
+      role {
+        name = "role-c"
+        policies = [
+          "p, proj:%[1]s:role-c, applications, get, %[1]s/*, allow",
+        ]
+      }
+    }
+  }
+	`, name)
 }
 
 func testAccArgoCDProjectWithClustersRepositoriesRolePolicy(name string) string {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What does this PR do / why we need it**:

Fixes a panic (`runtime error: index out of range`) when updating an `argocd_project` that removes one or more `role` blocks. The JWT-preservation loop in `projectResource.Update` used the index returned by `p.GetRoleByName()` — which refers to the *existing* project's role slice — to index `spec.Roles` (the new desired spec). When roles are removed, that index can exceed `len(spec.Roles)`, crashing the provider. The fix indexes `spec.Roles` by the loop position in the desired spec instead.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

(No docs change — behavior fix only.)

**Which issue(s) this PR fixes**:

Fixes #898

**How to test changes / Special notes to the reviewer**:

Added acceptance test `TestAccArgoCDProjectRemoveLeadingRoles`: creates a project with 3 roles, then updates keeping only the last role (index 2 in the existing project, index 0 in the new spec). Panics on `main`, passes with the fix.

```
make testacc TESTARGS='-run TestAccArgoCDProjectRemoveLeadingRoles'
```
