### PR TITLE
feat(argocd_applicationset): add values field to pull_request generator

### DIFF
--- a/argocd/resource_argocd_application_set_test.go
+++ b/argocd/resource_argocd_application_set_test.go
@@ -823,6 +823,11 @@ func TestAccArgoCDApplicationSet_pullRequestGithub(t *testing.T) {
 						"spec.0.generator.0.pull_request.0.github.0.labels.0",
 						"preview",
 					),
+					resource.TestCheckResourceAttr(
+						"argocd_application_set.pr_github",
+						"spec.0.generator.0.pull_request.0.values.foo",
+						"bar",
+					),
 				),
 			},
 			{
@@ -3018,6 +3023,10 @@ resource "argocd_application_set" "pr_github" {
 					labels = [
 						"preview"
 					]
+				}
+
+				values = {
+					foo = "bar"
 				}
 			}
 		}

--- a/argocd/schema_application_set.go
+++ b/argocd/schema_application_set.go
@@ -1080,6 +1080,12 @@ func applicationSetPullRequestGeneratorSchemaV0() *schema.Schema {
 					MaxItems:    1,
 					Elem:        applicationSetTemplateResource(true),
 				},
+				"values": {
+					Type:        schema.TypeMap,
+					Description: "Arbitrary string key-value pairs to pass to the template via the values field of the pull request generator.",
+					Optional:    true,
+					Elem:        &schema.Schema{Type: schema.TypeString},
+				},
 			},
 		},
 	}

--- a/argocd/structure_application_set.go
+++ b/argocd/structure_application_set.go
@@ -522,6 +522,10 @@ func expandApplicationSetPullRequestGeneratorGenerator(mg interface{}, featureMu
 		asg.PullRequest.Template = temp
 	}
 
+	if v, ok := m["values"]; ok {
+		asg.PullRequest.Values = expandStringMap(v.(map[string]interface{}))
+	}
+
 	return asg, nil
 }
 
@@ -1353,6 +1357,8 @@ func flattenApplicationSetPullRequestGenerator(prg *application.PullRequestGener
 	}
 
 	g["template"] = flattenApplicationSetTemplate(prg.Template)
+
+	g["values"] = prg.Values
 
 	return []map[string]interface{}{g}
 }

--- a/argocd/structure_application_set.go
+++ b/argocd/structure_application_set.go
@@ -522,8 +522,8 @@ func expandApplicationSetPullRequestGeneratorGenerator(mg interface{}, featureMu
 		asg.PullRequest.Template = temp
 	}
 
-	if v, ok := m["values"]; ok {
-		asg.PullRequest.Values = expandStringMap(v.(map[string]interface{}))
+	if v, ok := m["values"].(map[string]interface{}); ok {
+		asg.PullRequest.Values = expandStringMap(v)
 	}
 
 	return asg, nil

--- a/argocd/structure_application_set_test.go
+++ b/argocd/structure_application_set_test.go
@@ -1,0 +1,40 @@
+package argocd
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestExpandFlattenApplicationSetPullRequestGeneratorValues(t *testing.T) {
+	t.Parallel()
+
+	input := map[string]interface{}{
+		"values": map[string]interface{}{
+			"foo": "bar",
+			"env": "dev",
+		},
+	}
+
+	asg, err := expandApplicationSetPullRequestGeneratorGenerator(input, false, false)
+	if err != nil {
+		t.Fatalf("unexpected error expanding pull request generator: %s", err)
+	}
+
+	expectedValues := map[string]string{
+		"foo": "bar",
+		"env": "dev",
+	}
+
+	if !reflect.DeepEqual(asg.PullRequest.Values, expectedValues) {
+		t.Fatalf("expected expanded Values %v, got %v", expectedValues, asg.PullRequest.Values)
+	}
+
+	flattened := flattenApplicationSetPullRequestGenerator(asg.PullRequest)
+	if len(flattened) != 1 {
+		t.Fatalf("expected exactly one flattened pull request generator, got %d", len(flattened))
+	}
+
+	if !reflect.DeepEqual(flattened[0]["values"], expectedValues) {
+		t.Fatalf("expected flattened values %v, got %v", expectedValues, flattened[0]["values"])
+	}
+}

--- a/docs/resources/application_set.md
+++ b/docs/resources/application_set.md
@@ -428,6 +428,10 @@ resource "argocd_application_set" "pr_github" {
             "preview"
           ]
         }
+
+        values = {
+          env = "dev"
+        }
       }
     }
 
@@ -4685,6 +4689,7 @@ Optional:
 - `gitlab` (Block List, Max: 1) Specify the project from which to fetch the GitLab merge requests. (see [below for nested schema](#nestedblock--spec--generator--matrix--generator--matrix--generator--pull_request--gitlab))
 - `requeue_after_seconds` (String) How often to check for changes (in seconds). Default: 30min.
 - `template` (Block List, Max: 1) Generator template. Used to override the values of the spec-level template. (see [below for nested schema](#nestedblock--spec--generator--matrix--generator--matrix--generator--pull_request--template))
+- `values` (Map of String) Arbitrary string key-value pairs to pass to the template via the values field of the pull request generator.
 
 <a id="nestedblock--spec--generator--matrix--generator--matrix--generator--pull_request--azure_devops"></a>
 ### Nested Schema for `spec.generator.matrix.generator.matrix.generator.pull_request.azure_devops`
@@ -7384,6 +7389,7 @@ Optional:
 - `gitlab` (Block List, Max: 1) Specify the project from which to fetch the GitLab merge requests. (see [below for nested schema](#nestedblock--spec--generator--matrix--generator--merge--generator--pull_request--gitlab))
 - `requeue_after_seconds` (String) How often to check for changes (in seconds). Default: 30min.
 - `template` (Block List, Max: 1) Generator template. Used to override the values of the spec-level template. (see [below for nested schema](#nestedblock--spec--generator--matrix--generator--merge--generator--pull_request--template))
+- `values` (Map of String) Arbitrary string key-value pairs to pass to the template via the values field of the pull request generator.
 
 <a id="nestedblock--spec--generator--matrix--generator--merge--generator--pull_request--azure_devops"></a>
 ### Nested Schema for `spec.generator.matrix.generator.merge.generator.pull_request.azure_devops`
@@ -8856,6 +8862,7 @@ Optional:
 - `gitlab` (Block List, Max: 1) Specify the project from which to fetch the GitLab merge requests. (see [below for nested schema](#nestedblock--spec--generator--matrix--generator--pull_request--gitlab))
 - `requeue_after_seconds` (String) How often to check for changes (in seconds). Default: 30min.
 - `template` (Block List, Max: 1) Generator template. Used to override the values of the spec-level template. (see [below for nested schema](#nestedblock--spec--generator--matrix--generator--pull_request--template))
+- `values` (Map of String) Arbitrary string key-value pairs to pass to the template via the values field of the pull request generator.
 
 <a id="nestedblock--spec--generator--matrix--generator--pull_request--azure_devops"></a>
 ### Nested Schema for `spec.generator.matrix.generator.pull_request.azure_devops`
@@ -12783,6 +12790,7 @@ Optional:
 - `gitlab` (Block List, Max: 1) Specify the project from which to fetch the GitLab merge requests. (see [below for nested schema](#nestedblock--spec--generator--merge--generator--matrix--generator--pull_request--gitlab))
 - `requeue_after_seconds` (String) How often to check for changes (in seconds). Default: 30min.
 - `template` (Block List, Max: 1) Generator template. Used to override the values of the spec-level template. (see [below for nested schema](#nestedblock--spec--generator--merge--generator--matrix--generator--pull_request--template))
+- `values` (Map of String) Arbitrary string key-value pairs to pass to the template via the values field of the pull request generator.
 
 <a id="nestedblock--spec--generator--merge--generator--matrix--generator--pull_request--azure_devops"></a>
 ### Nested Schema for `spec.generator.merge.generator.matrix.generator.pull_request.azure_devops`
@@ -15482,6 +15490,7 @@ Optional:
 - `gitlab` (Block List, Max: 1) Specify the project from which to fetch the GitLab merge requests. (see [below for nested schema](#nestedblock--spec--generator--merge--generator--merge--generator--pull_request--gitlab))
 - `requeue_after_seconds` (String) How often to check for changes (in seconds). Default: 30min.
 - `template` (Block List, Max: 1) Generator template. Used to override the values of the spec-level template. (see [below for nested schema](#nestedblock--spec--generator--merge--generator--merge--generator--pull_request--template))
+- `values` (Map of String) Arbitrary string key-value pairs to pass to the template via the values field of the pull request generator.
 
 <a id="nestedblock--spec--generator--merge--generator--merge--generator--pull_request--azure_devops"></a>
 ### Nested Schema for `spec.generator.merge.generator.merge.generator.pull_request.azure_devops`
@@ -16954,6 +16963,7 @@ Optional:
 - `gitlab` (Block List, Max: 1) Specify the project from which to fetch the GitLab merge requests. (see [below for nested schema](#nestedblock--spec--generator--merge--generator--pull_request--gitlab))
 - `requeue_after_seconds` (String) How often to check for changes (in seconds). Default: 30min.
 - `template` (Block List, Max: 1) Generator template. Used to override the values of the spec-level template. (see [below for nested schema](#nestedblock--spec--generator--merge--generator--pull_request--template))
+- `values` (Map of String) Arbitrary string key-value pairs to pass to the template via the values field of the pull request generator.
 
 <a id="nestedblock--spec--generator--merge--generator--pull_request--azure_devops"></a>
 ### Nested Schema for `spec.generator.merge.generator.pull_request.azure_devops`
@@ -18426,6 +18436,7 @@ Optional:
 - `gitlab` (Block List, Max: 1) Specify the project from which to fetch the GitLab merge requests. (see [below for nested schema](#nestedblock--spec--generator--pull_request--gitlab))
 - `requeue_after_seconds` (String) How often to check for changes (in seconds). Default: 30min.
 - `template` (Block List, Max: 1) Generator template. Used to override the values of the spec-level template. (see [below for nested schema](#nestedblock--spec--generator--pull_request--template))
+- `values` (Map of String) Arbitrary string key-value pairs to pass to the template via the values field of the pull request generator.
 
 <a id="nestedblock--spec--generator--pull_request--azure_devops"></a>
 ### Nested Schema for `spec.generator.pull_request.azure_devops`

--- a/examples/resources/argocd_application_set/resource.tf
+++ b/examples/resources/argocd_application_set/resource.tf
@@ -413,6 +413,10 @@ resource "argocd_application_set" "pr_github" {
             "preview"
           ]
         }
+
+        values = {
+          env = "dev"
+        }
       }
     }
 


### PR DESCRIPTION
**What type of PR is this?**

/kind enhancement

**What does this PR do / why we need it**:

The `values` field is available on the `plugin`, `git`, `clusters` and `cluster_decision_resource` generators but not on `pull_request`, even though the upstream `PullRequestGenerator` type supports it. This PR adds `values` to the `pull_request` generator so it can be set from Terraform.

This is needed for the `merge(list, pull_request)` pattern, where `list` provides a baseline parameter set and `pull_request` overlays per-PR data on a shared mergekey. Without `values` on `pull_request` there is no way to set that key. 

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [x] Documentation has been updated.

**Which issue(s) this PR fixes**:

N/A

**How to test changes / Special notes to the reviewer**:

Added a unit test for the expand/flatten round-trip and extended `TestAccArgoCDApplicationSet_pullRequestGithub` to set and check `values`. The field is optional and additive, so existing configurations are unaffected.