### PR TITLE
fix(application): use sync policy for prune behavior on sync

### DIFF
--- a/argocd/resource_argocd_application.go
+++ b/argocd/resource_argocd_application.go
@@ -170,15 +170,27 @@ func resourceArgoCDApplicationCreate(ctx context.Context, d *schema.ResourceData
 
 	if sync, ok := d.GetOk("sync"); ok && sync.(bool) {
 		prune := false
-		if spec.SyncPolicy.Automated != nil && spec.SyncPolicy.Automated.Prune {
+		if spec.SyncPolicy != nil && spec.SyncPolicy.Automated != nil && spec.SyncPolicy.Automated.Prune {
 			prune = true
 		}
 
-		_, err := si.ApplicationClient.Sync(ctx, &applicationClient.ApplicationSyncRequest{
+		if spec.SyncPolicy != nil && spec.SyncPolicy.SyncOptions.HasOption("Prune=true") {
+			prune = true
+		}
+
+		syncRequest := &applicationClient.ApplicationSyncRequest{
 			Name:         &app.Name,
 			AppNamespace: &app.Namespace,
 			Prune:        &prune,
-		})
+		}
+
+		if spec.SyncPolicy != nil && len(spec.SyncPolicy.SyncOptions) > 0 {
+			syncRequest.SyncOptions = &applicationClient.SyncOptions{
+				Items: []string(spec.SyncPolicy.SyncOptions),
+			}
+		}
+
+		_, err := si.ApplicationClient.Sync(ctx, syncRequest)
 		if err != nil {
 			return errorToDiagnostics(fmt.Sprintf("error while triggering sync of application %s", app.Name), err)
 		}
@@ -342,15 +354,27 @@ func resourceArgoCDApplicationUpdate(ctx context.Context, d *schema.ResourceData
 
 	if sync, ok := d.GetOk("sync"); ok && sync.(bool) {
 		prune := false
-		if spec.SyncPolicy.Automated != nil && spec.SyncPolicy.Automated.Prune {
+		if spec.SyncPolicy != nil && spec.SyncPolicy.Automated != nil && spec.SyncPolicy.Automated.Prune {
 			prune = true
 		}
 
-		_, err = si.ApplicationClient.Sync(ctx, &applicationClient.ApplicationSyncRequest{
+		if spec.SyncPolicy != nil && spec.SyncPolicy.SyncOptions.HasOption("Prune=true") {
+			prune = true
+		}
+
+		syncRequest := &applicationClient.ApplicationSyncRequest{
 			Name:         &objectMeta.Name,
 			AppNamespace: &objectMeta.Namespace,
 			Prune:        &prune,
-		})
+		}
+
+		if spec.SyncPolicy != nil && len(spec.SyncPolicy.SyncOptions) > 0 {
+			syncRequest.SyncOptions = &applicationClient.SyncOptions{
+				Items: []string(spec.SyncPolicy.SyncOptions),
+			}
+		}
+
+		_, err = si.ApplicationClient.Sync(ctx, syncRequest)
 		if err != nil {
 			return errorToDiagnostics(fmt.Sprintf("error while triggering sync of application %s", *appQuery.Name), err)
 		}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What does this PR do / why we need it**:

Previously, setting sync policy to "Prune=true" does not trigger "prune" while syncing.

This PR fixes this issues.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #897 

**How to test changes / Special notes to the reviewer**:

Tested locally