### PR TITLE
feat: support gitea labels in application_set pull_request generator

### DIFF
--- a/argocd/resource_argocd_application_set_test.go
+++ b/argocd/resource_argocd_application_set_test.go
@@ -789,6 +789,11 @@ func TestAccArgoCDApplicationSet_pullRequestGitea(t *testing.T) {
 						"spec.0.generator.0.pull_request.0.gitea.0.owner",
 						"myorg",
 					),
+					resource.TestCheckResourceAttr(
+						"argocd_application_set.pr_gitea",
+						"spec.0.generator.0.pull_request.0.gitea.0.labels.0",
+						"preview",
+					),
 				),
 			},
 			{
@@ -2959,6 +2964,10 @@ resource "argocd_application_set" "pr_gitea" {
 						secret_name = "gitea-token"
 						key         = "token"
 					}
+
+					labels = [
+						"preview"
+					]
 				}
 			}
 		}

--- a/argocd/schema_application_set.go
+++ b/argocd/schema_application_set.go
@@ -955,6 +955,12 @@ func applicationSetPullRequestGeneratorSchemaV0() *schema.Schema {
 								Description: "Allow insecure tls, for self-signed certificates; default: false.",
 								Optional:    true,
 							},
+							"labels": {
+								Type:        schema.TypeList,
+								Description: "Labels is used to filter the PRs that you want to target.",
+								Optional:    true,
+								Elem:        &schema.Schema{Type: schema.TypeString},
+							},
 							"owner": {
 								Type:        schema.TypeString,
 								Description: "Gitea org or user to scan.",

--- a/argocd/structure_application_set.go
+++ b/argocd/structure_application_set.go
@@ -555,6 +555,12 @@ func expandApplicationSetPullRequestGeneratorGitea(g map[string]interface{}) *ap
 		Repo:     g["repo"].(string),
 	}
 
+	if v, ok := g["labels"].([]interface{}); ok && len(v) > 0 {
+		for _, l := range v {
+			prgg.Labels = append(prgg.Labels, l.(string))
+		}
+	}
+
 	if v, ok := g["token_ref"].([]interface{}); ok && len(v) > 0 {
 		prgg.TokenRef = expandSecretRef(v[0].(map[string]interface{}))
 	}
@@ -1385,6 +1391,10 @@ func flattenApplicationSetPullRequestGeneratorGitea(prgg *application.PullReques
 		"insecure": prgg.Insecure,
 		"owner":    prgg.Owner,
 		"repo":     prgg.Repo,
+	}
+
+	if len(prgg.Labels) > 0 {
+		g["labels"] = prgg.Labels
 	}
 
 	if prgg.TokenRef != nil {

--- a/docs/resources/application_set.md
+++ b/docs/resources/application_set.md
@@ -4763,6 +4763,7 @@ Required:
 Optional:
 
 - `insecure` (Boolean) Allow insecure tls, for self-signed certificates; default: false.
+- `labels` (List of String) Labels is used to filter the PRs that you want to target.
 - `token_ref` (Block List, Max: 1) Authentication token reference. (see [below for nested schema](#nestedblock--spec--generator--matrix--generator--matrix--generator--pull_request--gitea--token_ref))
 
 <a id="nestedblock--spec--generator--matrix--generator--matrix--generator--pull_request--gitea--token_ref"></a>
@@ -7462,6 +7463,7 @@ Required:
 Optional:
 
 - `insecure` (Boolean) Allow insecure tls, for self-signed certificates; default: false.
+- `labels` (List of String) Labels is used to filter the PRs that you want to target.
 - `token_ref` (Block List, Max: 1) Authentication token reference. (see [below for nested schema](#nestedblock--spec--generator--matrix--generator--merge--generator--pull_request--gitea--token_ref))
 
 <a id="nestedblock--spec--generator--matrix--generator--merge--generator--pull_request--gitea--token_ref"></a>
@@ -8934,6 +8936,7 @@ Required:
 Optional:
 
 - `insecure` (Boolean) Allow insecure tls, for self-signed certificates; default: false.
+- `labels` (List of String) Labels is used to filter the PRs that you want to target.
 - `token_ref` (Block List, Max: 1) Authentication token reference. (see [below for nested schema](#nestedblock--spec--generator--matrix--generator--pull_request--gitea--token_ref))
 
 <a id="nestedblock--spec--generator--matrix--generator--pull_request--gitea--token_ref"></a>
@@ -12861,6 +12864,7 @@ Required:
 Optional:
 
 - `insecure` (Boolean) Allow insecure tls, for self-signed certificates; default: false.
+- `labels` (List of String) Labels is used to filter the PRs that you want to target.
 - `token_ref` (Block List, Max: 1) Authentication token reference. (see [below for nested schema](#nestedblock--spec--generator--merge--generator--matrix--generator--pull_request--gitea--token_ref))
 
 <a id="nestedblock--spec--generator--merge--generator--matrix--generator--pull_request--gitea--token_ref"></a>
@@ -15560,6 +15564,7 @@ Required:
 Optional:
 
 - `insecure` (Boolean) Allow insecure tls, for self-signed certificates; default: false.
+- `labels` (List of String) Labels is used to filter the PRs that you want to target.
 - `token_ref` (Block List, Max: 1) Authentication token reference. (see [below for nested schema](#nestedblock--spec--generator--merge--generator--merge--generator--pull_request--gitea--token_ref))
 
 <a id="nestedblock--spec--generator--merge--generator--merge--generator--pull_request--gitea--token_ref"></a>
@@ -17032,6 +17037,7 @@ Required:
 Optional:
 
 - `insecure` (Boolean) Allow insecure tls, for self-signed certificates; default: false.
+- `labels` (List of String) Labels is used to filter the PRs that you want to target.
 - `token_ref` (Block List, Max: 1) Authentication token reference. (see [below for nested schema](#nestedblock--spec--generator--merge--generator--pull_request--gitea--token_ref))
 
 <a id="nestedblock--spec--generator--merge--generator--pull_request--gitea--token_ref"></a>
@@ -18504,6 +18510,7 @@ Required:
 Optional:
 
 - `insecure` (Boolean) Allow insecure tls, for self-signed certificates; default: false.
+- `labels` (List of String) Labels is used to filter the PRs that you want to target.
 - `token_ref` (Block List, Max: 1) Authentication token reference. (see [below for nested schema](#nestedblock--spec--generator--pull_request--gitea--token_ref))
 
 <a id="nestedblock--spec--generator--pull_request--gitea--token_ref"></a>


### PR DESCRIPTION
**What type of PR is this?**

/kind enhancement

**What does this PR do / why we need it**:

The `pull_request` generator's `gitea` block was missing the `labels` filter that
the `github` and `gitlab` blocks already expose. argo-cd v3.1.0 added label
filtering when an ApplicationSet scans a Gitea repo for open PRs
(argoproj/argo-cd#21148), but the provider had no way to set it. This adds the
`labels` field to the schema plus the expand/flatten wiring, mirroring the
existing `github`/`gitlab` implementation.

**Have you updated the necessary documentation?**

* [x] Documentation update is required by this PR.
* [x] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes #842

**How to test changes / Special notes to the reviewer**:

Extended `TestAccArgoCDApplicationSet_pullRequestGitea` with a `labels = ["preview"]`
config and an attribute check, matching the existing github/gitlab tests.

Local validation:
- make build / go vet: pass
- make lint (golangci-lint v2.11.4, CI-pinned): 0 issues
- make generate: docs regenerated (gitea labels only)
- make testacc (TestAccArgoCDApplicationSet_pullRequestGitea): PASS against
  k3s + ArgoCD v3.3.0 via testcontainers
