### PR TITLE
fix: remove broken windows_arm go port from goreleaser's build targets

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,7 +15,6 @@ builds:
       - linux_arm
       - linux_arm64
       - windows_amd64
-      - windows_arm
       - windows_386
       - freebsd_amd64
       - freebsd_arm


### PR DESCRIPTION
**What type of PR is this?**

[//]: # (Uncomment only one <!-- /kind ... --> line, and delete the rest.)
[//]: # (For example, <!-- /kind bug --> would simply become: /kind bug  )

/kind bug
<!-- /kind bug -->
<!-- /kind chore -->
<!-- /kind cleanup -->
<!-- /kind failing-test -->
<!-- /kind enhancement -->
<!-- /kind documentation -->
<!-- /kind code-refactoring -->


**What does this PR do / why we need it**:

#892 bumped to go 1.26 which removed support for `windows_arm`. Currently the release is failing due to this.

**Have you updated the necessary documentation?**

* [ ] Documentation update is required by this PR.
* [ ] Documentation has been updated.

**Which issue(s) this PR fixes**:

Fixes currently failed release

**How to test changes / Special notes to the reviewer**:

See https://go.dev/doc/go1.26#windows for the release notes